### PR TITLE
Work on tasks and stack

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,10 +122,24 @@ cpmaddpackage("gh:ZIMO-Elektronik/ULF_MDU_EIN@0.0.0")
 cpmaddpackage("gh:ZIMO-Elektronik/ULF_SUSIV2@0.2.0")
 cpmaddpackage("gh:ZIMO-Elektronik/ZUSI@0.9.2")
 cpmaddpackage("gh:microsoft/GSL@4.2.0")
-cpmaddpackage("gh:Neargye/magic_enum@0.9.7")
+cpmaddpackage(
+  NAME
+  Boost
+  VERSION
+  1.88.0
+  URL
+  https://github.com/boostorg/boost/releases/download/boost-1.88.0/boost-1.88.0-cmake.tar.gz
+  URL_HASH
+  SHA256=dcea50f40ba1ecfc448fdf886c0165cf3e525fef2c9e3e080b9804e8117b9694
+  OPTIONS
+  "BOOST_ENABLE_CMAKE ON"
+  "BOOST_SKIP_INSTALL_RULES ON"
+  "BUILD_SHARED_LIBS OFF"
+  "BOOST_INCLUDE_LIBRARIES preprocessor")
 
 # According to this answer here https://stackoverflow.com/a/55312360/5840652
 # magic enum works up to INT16_MAX
+cpmaddpackage("gh:Neargye/magic_enum@0.9.7")
 math(EXPR INT16_MAX "(1 << 15) - 1" OUTPUT_FORMAT DECIMAL)
 target_compile_definitions(
   magic_enum INTERFACE MAGIC_ENUM_RANGE_MIN=0 MAGIC_ENUM_RANGE_MAX=${INT16_MAX})
@@ -146,7 +160,8 @@ cpmaddpackage(
 
 target_link_libraries(
   ${COMPONENT_LIB}
-  PUBLIC fmt::fmt
+  PUBLIC Boost::preprocessor
+         fmt::fmt
          magic_enum::magic_enum
          Microsoft.GSL::GSL
          ULF::COM

--- a/src/app_main.cpp
+++ b/src/app_main.cpp
@@ -87,3 +87,36 @@ extern "C" void app_main() {
                 APP_CPU_NUM == intf::usb::tx_task.core_id);
 #endif
 }
+
+// Assert that task names are unique and below max length
+static_assert(std::invoke([] {
+  std::array task_names{drv::analog::adc_task.name,
+                        drv::analog::temp_task.name,
+                        drv::out::track::dcc::task.name,
+                        drv::out::track::decup::task.name,
+                        drv::out::track::mdu::task.name,
+                        drv::out::zusi::task.name,
+                        drv::wifi::task.name,
+                        intf::usb::rx_task.name,
+                        intf::usb::tx_task.name,
+                        mw::dcc::task.name,
+                        mw::decup::task.name,
+                        mw::mdu::task.name,
+                        mw::ota::task.name,
+                        mw::ulf::dcc_ein::task.name,
+                        mw::ulf::decup_ein::task.name,
+                        mw::ulf::susiv2::task.name,
+                        mw::z21::task.name,
+                        mw::zusi::task.name};
+  std::ranges::sort(task_names, [](char const* a, char const* b) {
+    return ztl::strcmp(a, b) < 0;
+  });
+
+  return
+    // Names are unique
+    std::unique(begin(task_names), end(task_names)) == cend(task_names) &&
+    // ... and short enough
+    std::ranges::all_of(task_names, [](char const* a) {
+      return ztl::strlen(a) <= CONFIG_FREERTOS_MAX_TASK_NAME_LEN;
+    });
+}));

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -38,6 +38,7 @@
 #include <ztl/enum.hpp>
 #include <ztl/implicit_wrapper.hpp>
 #include <ztl/limits.hpp>
+#include <ztl/string.hpp>
 #include "task.hpp"
 
 #if CONFIG_IDF_TARGET_ESP32S3
@@ -294,6 +295,9 @@ inline constexpr auto wifi_channel{LEDC_CHANNEL_1};
 
 namespace out {
 
+///
+inline std::array<StackType_t, 4096uz> stack{};
+
 #if !CONFIG_IDF_TARGET_LINUX
 inline gptimer_handle_t gptimer{};
 #endif
@@ -352,36 +356,33 @@ inline constexpr auto bidi_rx_gpio_num{GPIO_NUM_14};
 inline constexpr auto bidi_en_gpio_num{GPIO_NUM_13};
 
 ///
-inline TASK(task,
-            "drv::out::track::dcc", // Name
-            4096uz,                 // Stack size
-            ESP_TASK_PRIO_MAX - 1u, // Priority
-            APP_CPU_NUM,            // Core
-            0u);
+inline SHARED_TASK(task,
+                   "drv::out::track::dcc", // Name
+                   ESP_TASK_PRIO_MAX - 1u, // Priority
+                   APP_CPU_NUM,            // Core
+                   0u);
 
 } // namespace dcc
 
 namespace decup {
 
 ///
-inline TASK(task,
-            "drv::out::track::decup", // Name
-            4096uz,                   // Stack size
-            ESP_TASK_PRIO_MAX - 1u,   // Priority
-            APP_CPU_NUM,              // Core
-            60'000u);                 // Timeout
+inline SHARED_TASK(task,
+                   "drv::out::track::decup", // Name
+                   ESP_TASK_PRIO_MAX - 1u,   // Priority
+                   APP_CPU_NUM,              // Core
+                   60'000u);                 // Timeout
 
 } // namespace decup
 
 namespace mdu {
 
 ///
-inline TASK(task,
-            "drv::out::track::mdu", // Name
-            4096uz,                 // Stack size
-            ESP_TASK_PRIO_MAX - 1u, // Priority
-            APP_CPU_NUM,            // Core
-            0u);
+inline SHARED_TASK(task,
+                   "drv::out::track::mdu", // Name
+                   ESP_TASK_PRIO_MAX - 1u, // Priority
+                   APP_CPU_NUM,            // Core
+                   0u);
 
 } // namespace mdu
 
@@ -394,12 +395,11 @@ inline constexpr auto clock_gpio_num{GPIO_NUM_6};
 inline constexpr auto data_gpio_num{GPIO_NUM_5};
 
 ///
-inline TASK(task,
-            "drv::out::zusi",       // Name
-            4096uz,                 // Stack size
-            ESP_TASK_PRIO_MAX - 1u, // Priority
-            APP_CPU_NUM,            // Core
-            0u);
+inline SHARED_TASK(task,
+                   "drv::out::zusi",       // Name
+                   ESP_TASK_PRIO_MAX - 1u, // Priority
+                   APP_CPU_NUM,            // Core
+                   0u);
 
 } // namespace zusi
 
@@ -618,7 +618,7 @@ inline std::shared_ptr<Service> service;
 
 namespace zusi {
 
-/// \todo ESP_TASK_PRIO_MAX
+///
 inline TASK(task,
             "mw::zusi",  // Name
             4096uz,      // Stack size

--- a/src/drv/analog/adc_task_function.cpp
+++ b/src/drv/analog/adc_task_function.cpp
@@ -58,7 +58,7 @@ auto get_short_circuit_count() {
 /// "bug LED" is switched on, \ref state is set to \ref State::ShortCircuit
 /// "short circuit" and a \ref page_z21 track short circuit message is
 /// broadcast.
-void adc_task_function(void*) {
+[[noreturn]] void adc_task_function(void*) {
   std::array<uint8_t, conversion_frame_size> conversion_frame{};
   auto short_circuit_count{get_short_circuit_count()};
 

--- a/src/drv/analog/adc_task_function.hpp
+++ b/src/drv/analog/adc_task_function.hpp
@@ -23,6 +23,6 @@
 
 namespace drv::analog {
 
-void adc_task_function(void*);
+[[noreturn]] void adc_task_function(void*);
 
 } // namespace drv::analog

--- a/src/drv/analog/temp_task_function.cpp
+++ b/src/drv/analog/temp_task_function.cpp
@@ -29,7 +29,7 @@ namespace drv::analog {
 /// Once started, the temperature task runs continuously. The internal
 /// temperature sensor is read once per second and the result is converted into
 /// degrees Celsius. The result is written to the corresponding queue.
-void temp_task_function(void*) {
+[[noreturn]] void temp_task_function(void*) {
   for (;;) {
     TemperatureQueue::value_type temp;
     ESP_ERROR_CHECK(temperature_sensor_get_celsius(temp_sensor, &temp));

--- a/src/drv/analog/temp_task_function.hpp
+++ b/src/drv/analog/temp_task_function.hpp
@@ -23,6 +23,6 @@
 
 namespace drv::analog {
 
-void temp_task_function(void*);
+[[noreturn]] void temp_task_function(void*);
 
 } // namespace drv::analog

--- a/src/drv/out/suspend.cpp
+++ b/src/drv/out/suspend.cpp
@@ -24,6 +24,8 @@
 
 namespace drv::out {
 
+namespace {
+
 /// \todo document
 void reset_queue_and_message_buffers() {
   xQueueReset(track::rx_queue.handle);
@@ -38,6 +40,8 @@ void reset_queue_and_message_buffers() {
     vTaskDelay(pdMS_TO_TICKS(20u));
   }
 }
+
+} // namespace
 
 /// \todo document
 esp_err_t suspend() {

--- a/src/drv/out/suspend.hpp
+++ b/src/drv/out/suspend.hpp
@@ -25,7 +25,6 @@
 
 namespace drv::out {
 
-void reset_queue_and_message_buffers();
 esp_err_t suspend();
 
 } // namespace drv::out

--- a/src/drv/out/track/dcc/task_function.cpp
+++ b/src/drv/out/track/dcc/task_function.cpp
@@ -382,23 +382,24 @@ esp_err_t service_loop(dcc_encoder_config_t const&) {
 
 /// \todo document
 void task_function(void*) {
-  for (;;) switch (auto encoder_config{dcc_encoder_config()}; state.load()) {
-      case State::DCCOperations: [[fallthrough]];
-      case State::ULF_DCC_EIN:
-        ESP_ERROR_CHECK(
-          resume(encoder_config,
-                 encoder_config.bidibit_duration ? rmt_callback : NULL,
-                 encoder_config.bidibit_duration ? gptimer_callback : NULL));
-        ESP_ERROR_CHECK(operations_loop(encoder_config));
-        ESP_ERROR_CHECK(suspend());
-        break;
-      case State::DCCService:
-        ESP_ERROR_CHECK(resume(encoder_config, nullptr, nullptr));
-        ESP_ERROR_CHECK(service_loop(encoder_config));
-        ESP_ERROR_CHECK(suspend());
-        break;
-      default: LOGI_TASK_SUSPEND(); break;
-    }
+  switch (auto encoder_config{dcc_encoder_config()}; state.load()) {
+    case State::DCCOperations: [[fallthrough]];
+    case State::ULF_DCC_EIN:
+      ESP_ERROR_CHECK(
+        resume(encoder_config,
+               encoder_config.bidibit_duration ? rmt_callback : NULL,
+               encoder_config.bidibit_duration ? gptimer_callback : NULL));
+      ESP_ERROR_CHECK(operations_loop(encoder_config));
+      ESP_ERROR_CHECK(suspend());
+      break;
+    case State::DCCService:
+      ESP_ERROR_CHECK(resume(encoder_config, nullptr, nullptr));
+      ESP_ERROR_CHECK(service_loop(encoder_config));
+      ESP_ERROR_CHECK(suspend());
+      break;
+    default: assert(false); break;
+  }
+  LOGI_TASK_DESTROY();
 }
 
 } // namespace drv::out::track::dcc

--- a/src/drv/out/track/dcc/task_function.cpp
+++ b/src/drv/out/track/dcc/task_function.cpp
@@ -381,7 +381,7 @@ esp_err_t service_loop(dcc_encoder_config_t const&) {
 } // namespace
 
 /// \todo document
-void task_function(void*) {
+[[noreturn]] void task_function(void*) {
   switch (auto encoder_config{dcc_encoder_config()}; state.load()) {
     case State::DCCOperations: [[fallthrough]];
     case State::ULF_DCC_EIN:

--- a/src/drv/out/track/dcc/task_function.hpp
+++ b/src/drv/out/track/dcc/task_function.hpp
@@ -23,6 +23,6 @@
 
 namespace drv::out::track::dcc {
 
-void task_function(void*);
+[[noreturn]] void task_function(void*);
 
 } // namespace drv::out::track::dcc

--- a/src/drv/out/track/decup/task_function.cpp
+++ b/src/drv/out/track/decup/task_function.cpp
@@ -155,7 +155,7 @@ esp_err_t test_loop(uint8_t decoder_id = 221u) {
 } // namespace
 
 /// \todo document
-void task_function(void*) {
+[[noreturn]] void task_function(void*) {
   switch (decup_encoder_config_t encoder_config{}; state.load()) {
     case State::DECUPZpp: [[fallthrough]];
     case State::DECUPZsu: [[fallthrough]];

--- a/src/drv/out/track/decup/task_function.cpp
+++ b/src/drv/out/track/decup/task_function.cpp
@@ -156,16 +156,17 @@ esp_err_t test_loop(uint8_t decoder_id = 221u) {
 
 /// \todo document
 void task_function(void*) {
-  for (;;) switch (decup_encoder_config_t encoder_config{}; state.load()) {
-      case State::DECUPZpp: [[fallthrough]];
-      case State::DECUPZsu: [[fallthrough]];
-      case State::ULF_DECUP_EIN:
-        ESP_ERROR_CHECK(resume(encoder_config, rmt_callback, ack_isr_handler));
-        ESP_ERROR_CHECK(loop());
-        ESP_ERROR_CHECK(suspend());
-        break;
-      default: LOGI_TASK_SUSPEND(); break;
-    }
+  switch (decup_encoder_config_t encoder_config{}; state.load()) {
+    case State::DECUPZpp: [[fallthrough]];
+    case State::DECUPZsu: [[fallthrough]];
+    case State::ULF_DECUP_EIN:
+      ESP_ERROR_CHECK(resume(encoder_config, rmt_callback, ack_isr_handler));
+      ESP_ERROR_CHECK(loop());
+      ESP_ERROR_CHECK(suspend());
+      break;
+    default: assert(false); break;
+  }
+  LOGI_TASK_DESTROY();
 }
 
 } // namespace drv::out::track::decup

--- a/src/drv/out/track/decup/task_function.hpp
+++ b/src/drv/out/track/decup/task_function.hpp
@@ -23,6 +23,6 @@
 
 namespace drv::out::track::decup {
 
-void task_function(void*);
+[[noreturn]] void task_function(void*);
 
 } // namespace drv::out::track::decup

--- a/src/drv/out/track/init.cpp
+++ b/src/drv/out/track/init.cpp
@@ -142,9 +142,9 @@ esp_err_t init() {
   ESP_ERROR_CHECK(init_channel());
   ESP_ERROR_CHECK(init_gpio());
 
-  dcc::task.create(dcc::task_function);
-  decup::task.create(decup::task_function);
-  mdu::task.create(mdu::task_function);
+  dcc::task.function = dcc::task_function;
+  decup::task.function = decup::task_function;
+  mdu::task.function = mdu::task_function;
 
   return ESP_OK;
 }

--- a/src/drv/out/track/mdu/task_function.cpp
+++ b/src/drv/out/track/mdu/task_function.cpp
@@ -293,17 +293,18 @@ esp_err_t loop(mdu_encoder_config_t& encoder_config) {
 
 /// \todo document
 void task_function(void*) {
-  for (;;) switch (auto encoder_config{mdu_encoder_config()}; state.load()) {
-      case State::MDUZpp: ESP_ERROR_CHECK(zpp_entry()); [[fallthrough]];
-      case State::MDUZsu: [[fallthrough]];
-      case State::ULF_MDU_EIN:
-        ESP_ERROR_CHECK(resume(encoder_config, ack_isr_handler));
-        ESP_ERROR_CHECK(zsu_entry());
-        ESP_ERROR_CHECK(loop(encoder_config));
-        ESP_ERROR_CHECK(suspend());
-        break;
-      default: LOGI_TASK_SUSPEND(); break;
-    }
+  switch (auto encoder_config{mdu_encoder_config()}; state.load()) {
+    case State::MDUZpp: ESP_ERROR_CHECK(zpp_entry()); [[fallthrough]];
+    case State::MDUZsu: [[fallthrough]];
+    case State::ULF_MDU_EIN:
+      ESP_ERROR_CHECK(resume(encoder_config, ack_isr_handler));
+      ESP_ERROR_CHECK(zsu_entry());
+      ESP_ERROR_CHECK(loop(encoder_config));
+      ESP_ERROR_CHECK(suspend());
+      break;
+    default: assert(false); break;
+  }
+  LOGI_TASK_DESTROY();
 }
 
 } // namespace drv::out::track::mdu

--- a/src/drv/out/track/mdu/task_function.cpp
+++ b/src/drv/out/track/mdu/task_function.cpp
@@ -292,7 +292,7 @@ esp_err_t loop(mdu_encoder_config_t& encoder_config) {
 } // namespace
 
 /// \todo document
-void task_function(void*) {
+[[noreturn]] void task_function(void*) {
   switch (auto encoder_config{mdu_encoder_config()}; state.load()) {
     case State::MDUZpp: ESP_ERROR_CHECK(zpp_entry()); [[fallthrough]];
     case State::MDUZsu: [[fallthrough]];

--- a/src/drv/out/track/mdu/task_function.hpp
+++ b/src/drv/out/track/mdu/task_function.hpp
@@ -23,6 +23,6 @@
 
 namespace drv::out::track::mdu {
 
-void task_function(void*);
+[[noreturn]] void task_function(void*);
 
 } // namespace drv::out::track::mdu

--- a/src/drv/out/zusi/init.cpp
+++ b/src/drv/out/zusi/init.cpp
@@ -73,7 +73,7 @@ esp_err_t init() {
   devcfg.clock_speed_hz = static_cast<int>(1.0 / 0.5533e-6);
   spi_bus_add_device(SPI2_HOST, &devcfg, &spis[3uz]);
 
-  task.create(task_function);
+  task.function = task_function;
 
   return ESP_OK;
 }

--- a/src/drv/out/zusi/task_function.cpp
+++ b/src/drv/out/zusi/task_function.cpp
@@ -141,15 +141,16 @@ void loop() {
 
 /// \todo document
 void task_function(void*) {
-  for (;;) switch (state.load()) {
-      case State::ZUSI: [[fallthrough]];
-      case State::ULF_SUSIV2:
-        ESP_ERROR_CHECK(resume());
-        loop();
-        ESP_ERROR_CHECK(suspend());
-        break;
-      default: LOGI_TASK_SUSPEND(); break;
-    }
+  switch (state.load()) {
+    case State::ZUSI: [[fallthrough]];
+    case State::ULF_SUSIV2:
+      ESP_ERROR_CHECK(resume());
+      loop();
+      ESP_ERROR_CHECK(suspend());
+      break;
+    default: assert(false); break;
+  }
+  LOGI_TASK_DESTROY();
 }
 
 } // namespace drv::out::zusi

--- a/src/drv/out/zusi/task_function.cpp
+++ b/src/drv/out/zusi/task_function.cpp
@@ -140,7 +140,7 @@ void loop() {
 }
 
 /// \todo document
-void task_function(void*) {
+[[noreturn]] void task_function(void*) {
   switch (state.load()) {
     case State::ZUSI: [[fallthrough]];
     case State::ULF_SUSIV2:

--- a/src/drv/out/zusi/task_function.hpp
+++ b/src/drv/out/zusi/task_function.hpp
@@ -23,6 +23,6 @@
 
 namespace drv::out::zusi {
 
-void task_function(void*);
+[[noreturn]] void task_function(void*);
 
 } // namespace drv::out::zusi

--- a/src/drv/wifi/task_function.cpp
+++ b/src/drv/wifi/task_function.cpp
@@ -41,7 +41,7 @@ void reset_sta_settings() {
 } // namespace
 
 /// \todo document
-void task_function(void*) {
+[[noreturn]] void task_function(void*) {
   size_t seconds{};
 
   for (;;) {

--- a/src/drv/wifi/task_function.cpp
+++ b/src/drv/wifi/task_function.cpp
@@ -51,7 +51,7 @@ void task_function(void*) {
     drv::led::bug(true);
     reset_sta_settings();
     esp_delayed_restart();
-    vTaskDelete(NULL);
+    LOGI_TASK_DESTROY();
   }
 }
 

--- a/src/drv/wifi/task_function.hpp
+++ b/src/drv/wifi/task_function.hpp
@@ -23,6 +23,6 @@
 
 namespace drv::wifi {
 
-void task_function(void*);
+[[noreturn]] void task_function(void*);
 
 } // namespace drv::wifi

--- a/src/intf/usb/rx_task_function.cpp
+++ b/src/intf/usb/rx_task_function.cpp
@@ -115,18 +115,16 @@ void wait_for_all_service_tasks_to_suspend() {
 /// The receive task scans the CDC character stream for commands. Those commands
 /// could either be general ones (e.g. `PING\r`) or protocol entry strings. When
 /// a protocol entry string is detected the corrsponding task is created and the
-/// receive task suspends itself.
+/// receive task destroys itself.
 ///
 /// Currently supported protocols are:
 /// - [ULF_DCC_EIN](https://github.com/ZIMO-Elektronik/ULF_DCC_EIN)
 /// - [ULF_DECUP_EIN](https://github.com/ZIMO-Elektronik/ULF_DECUP_EIN)
 /// - [ULF_SUSIV2](https://github.com/ZIMO-Elektronik/ULF_SUSIV2)
 void rx_task_function(void*) {
-  for (;;) {
-    loop();
-    LOGI_TASK_SUSPEND();
-    wait_for_all_service_tasks_to_suspend();
-  }
+  wait_for_all_service_tasks_to_suspend();
+  loop();
+  LOGI_TASK_DESTROY();
 }
 
 } // namespace intf::usb

--- a/src/intf/usb/rx_task_function.cpp
+++ b/src/intf/usb/rx_task_function.cpp
@@ -79,20 +79,20 @@ void loop() {
       if (cmd == std::nullopt) continue;
       // Ping
       else if (cmd == "PING\r"sv) transmit_ping();
-      // Resume ULF_DCC_EIN task
+      // Create ULF_DCC_EIN task
       else if (cmd == "DCC_EIN\r"sv) {
         LOGI_TASK_CREATE(mw::ulf::dcc_ein::task);
         break;
       }
-      // Resume ULF_DECUP_EIN task
+      // Create ULF_DECUP_EIN task
       else if (cmd == "DECUP_EIN\r"sv) {
         LOGI_TASK_CREATE(mw::ulf::decup_ein::task);
         break;
       }
-      // Resume ULF_MDU_EIN task
+      // Create ULF_MDU_EIN task
       else if (cmd == "MDU_EIN\r"sv)
         LOGW("MDU_EIN not implemented");
-      // Resume ULF_SUSIV2 task
+      // Create ULF_SUSIV2 task
       else if (cmd == "SUSIV2\r"sv) {
         LOGI_TASK_CREATE(mw::ulf::susiv2::task);
         break;
@@ -121,7 +121,7 @@ void wait_for_all_service_tasks_to_suspend() {
 /// - [ULF_DCC_EIN](https://github.com/ZIMO-Elektronik/ULF_DCC_EIN)
 /// - [ULF_DECUP_EIN](https://github.com/ZIMO-Elektronik/ULF_DECUP_EIN)
 /// - [ULF_SUSIV2](https://github.com/ZIMO-Elektronik/ULF_SUSIV2)
-void rx_task_function(void*) {
+[[noreturn]] void rx_task_function(void*) {
   wait_for_all_service_tasks_to_suspend();
   loop();
   LOGI_TASK_DESTROY();

--- a/src/intf/usb/rx_task_function.hpp
+++ b/src/intf/usb/rx_task_function.hpp
@@ -23,6 +23,7 @@
 
 namespace intf::usb {
 
-void rx_task_function(void*);
+bool any_service_task_active();
+[[noreturn]] void rx_task_function(void*);
 
 } // namespace intf::usb

--- a/src/intf/usb/tx_task_function.cpp
+++ b/src/intf/usb/tx_task_function.cpp
@@ -76,7 +76,7 @@ void flush() {
 ///
 /// The transmit task receives data from \ref tx_stream_buffer and transmit it
 /// to the CDC device queue.
-void tx_task_function(void*) {
+[[noreturn]] void tx_task_function(void*) {
   std::array<uint8_t, buffer_size> stack;
   for (;;) {
     auto const bytes_received{receive(stack)};

--- a/src/intf/usb/tx_task_function.hpp
+++ b/src/intf/usb/tx_task_function.hpp
@@ -25,6 +25,6 @@ namespace intf::usb {
 
 void transmit_ok();
 void transmit_not_ok();
-void tx_task_function(void*);
+[[noreturn]] void tx_task_function(void*);
 
 } // namespace intf::usb

--- a/src/mw/dcc/service.cpp
+++ b/src/mw/dcc/service.cpp
@@ -187,8 +187,8 @@ void Service::operationsLoop() {
     if (!empty(_cv_request_deque)) return serviceLoop();
   }
 
-  // wait for task to get suspended
-  while (eTaskGetState(drv::out::track::dcc::task.handle) != eSuspended)
+  // wait for task to get deleted
+  while (xTaskGetHandle("drv::out::track::dcc"))
     vTaskDelay(pdMS_TO_TICKS(task.timeout));
 }
 
@@ -441,8 +441,8 @@ void Service::serviceLoop() {
   if (auto expected{State::DCCOperations};
       state.compare_exchange_strong(expected, State::Suspend)) {
 
-    // wait for task to get suspended
-    while (eTaskGetState(drv::out::track::dcc::task.handle) != eSuspended)
+    // wait for task to get deleted
+    while (xTaskGetHandle("drv::out::track::dcc"))
       vTaskDelay(pdMS_TO_TICKS(task.timeout));
 
     // switch to serv mode
@@ -450,8 +450,8 @@ void Service::serviceLoop() {
     if (!state.compare_exchange_strong(expected, State::DCCService))
       assert(false);
 
-    // then resume
-    LOGI_TASK_RESUME(drv::out::track::dcc::task);
+    // then create
+    LOGI_TASK_CREATE(drv::out::track::dcc::task);
   }
 
   auto const& req{_cv_request_deque.front()};
@@ -460,8 +460,8 @@ void Service::serviceLoop() {
                            : serviceRead(cv_addr)};
   _cv_request_deque.pop_front();
 
-  // wait for task to get suspended
-  while (eTaskGetState(drv::out::track::dcc::task.handle) != eSuspended)
+  // wait for task to get deleted
+  while (xTaskGetHandle("drv::out::track::dcc"))
     vTaskDelay(pdMS_TO_TICKS(task.timeout));
 
   // send reply
@@ -826,7 +826,7 @@ void Service::resume() {
     sendToBack(packet);
 
   // Resume out::track::dcc task
-  LOGI_TASK_RESUME(drv::out::track::dcc::task);
+  LOGI_TASK_CREATE(drv::out::track::dcc::task);
 }
 
 /// \todo document

--- a/src/mw/dcc/service.cpp
+++ b/src/mw/dcc/service.cpp
@@ -35,7 +35,8 @@ Service::Service() {
     auto const addr{nvs.key2address(entry_info.key)};
     dynamic_cast<NvLocoBase&>(_locos[addr]) = nvs.get(entry_info.key);
   }
-  task.create(ztl::make_trampoline(this, &Service::taskFunction));
+
+  task.function = ztl::make_trampoline(this, &Service::taskFunction);
 }
 
 /// \todo document
@@ -161,19 +162,20 @@ intf::http::Response Service::locosPutRequest(intf::http::Request const& req) {
 
 /// \todo document
 void Service::taskFunction(void*) {
-  for (;;) switch (state.load()) {
-      case State::DCCOperations:
-        resume();
-        operationsLoop();
-        suspend();
-        break;
-      case State::DCCService:
-        resume();
-        serviceLoop();
-        suspend();
-        break;
-      default: LOGI_TASK_SUSPEND(); break;
-    }
+  switch (state.load()) {
+    case State::DCCOperations:
+      resume();
+      operationsLoop();
+      suspend();
+      break;
+    case State::DCCService:
+      resume();
+      serviceLoop();
+      suspend();
+      break;
+    default: assert(false); break;
+  }
+  LOGI_TASK_DESTROY();
 }
 
 /// \todo document

--- a/src/mw/dcc/service.cpp
+++ b/src/mw/dcc/service.cpp
@@ -161,7 +161,7 @@ intf::http::Response Service::locosPutRequest(intf::http::Request const& req) {
 }
 
 /// \todo document
-void Service::taskFunction(void*) {
+[[noreturn]] void Service::taskFunction(void*) {
   switch (state.load()) {
     case State::DCCOperations:
       resume();
@@ -827,7 +827,7 @@ void Service::resume() {
     drv::out::tx_message_buffer.size * 0.5)
     sendToBack(packet);
 
-  // Resume out::track::dcc task
+  // Create out::track::dcc task
   LOGI_TASK_CREATE(drv::out::track::dcc::task);
 }
 

--- a/src/mw/dcc/service.hpp
+++ b/src/mw/dcc/service.hpp
@@ -40,7 +40,7 @@ public:
 
 private:
   // This gets called by FreeRTOS
-  void taskFunction(void*);
+  [[noreturn]] void taskFunction(void*);
 
   void operationsLoop();
   void operationsDcc();

--- a/src/mw/decup/service.cpp
+++ b/src/mw/decup/service.cpp
@@ -63,7 +63,7 @@ esp_err_t Service::socket(intf::http::Message& msg, State decup_state) {
 }
 
 /// \todo document
-void Service::taskFunction(void*) {
+[[noreturn]] void Service::taskFunction(void*) {
   switch (state.load()) {
     case State::DECUPZpp: [[fallthrough]];
     case State::DECUPZsu: loop(); break;

--- a/src/mw/decup/service.cpp
+++ b/src/mw/decup/service.cpp
@@ -26,7 +26,7 @@ using ::ulf::decup_ein::ack, ::ulf::decup_ein::nak;
 
 /// \todo document
 Service::Service() {
-  task.create(ztl::make_trampoline(this, &Service::taskFunction));
+  task.function = ztl::make_trampoline(this, &Service::taskFunction);
 }
 
 /// \todo document
@@ -49,8 +49,7 @@ esp_err_t Service::socket(intf::http::Message& msg, State decup_state) {
       msg.type != HTTPD_WS_TYPE_CLOSE &&
       state.compare_exchange_strong(expected, decup_state)) {
     _queue.push(std::move(msg));
-    LOGI_TASK_RESUME(task);
-    LOGI_TASK_CREATE(drv::out::track::decup::task);
+    LOGI_TASKS_CREATE(task, drv::out::track::decup::task);
     return ESP_OK;
   }
   //
@@ -65,14 +64,12 @@ esp_err_t Service::socket(intf::http::Message& msg, State decup_state) {
 
 /// \todo document
 void Service::taskFunction(void*) {
-  for (;;) {
-    LOGI_TASK_SUSPEND();
-    switch (state.load()) {
-      case State::DECUPZpp: [[fallthrough]];
-      case State::DECUPZsu: loop(); break;
-      default: assert(false); break;
-    }
+  switch (state.load()) {
+    case State::DECUPZpp: [[fallthrough]];
+    case State::DECUPZsu: loop(); break;
+    default: assert(false); break;
   }
+  LOGI_TASK_DESTROY();
 }
 
 /// \todo document

--- a/src/mw/decup/service.cpp
+++ b/src/mw/decup/service.cpp
@@ -50,7 +50,7 @@ esp_err_t Service::socket(intf::http::Message& msg, State decup_state) {
       state.compare_exchange_strong(expected, decup_state)) {
     _queue.push(std::move(msg));
     LOGI_TASK_RESUME(task);
-    LOGI_TASK_RESUME(drv::out::track::decup::task);
+    LOGI_TASK_CREATE(drv::out::track::decup::task);
     return ESP_OK;
   }
   //

--- a/src/mw/decup/service.hpp
+++ b/src/mw/decup/service.hpp
@@ -32,7 +32,7 @@ public:
 
 private:
   esp_err_t socket(intf::http::Message& msg, State decup_state);
-  void taskFunction(void*);
+  [[noreturn]] void taskFunction(void*);
   void loop();
 
   uint8_t transmit(std::span<uint8_t const> bytes) final;

--- a/src/mw/mdu/service.cpp
+++ b/src/mw/mdu/service.cpp
@@ -63,7 +63,7 @@ esp_err_t Service::socket(intf::http::Message& msg, State mdu_state) {
 }
 
 /// \todo document
-void Service::taskFunction(void*) {
+[[noreturn]] void Service::taskFunction(void*) {
   switch (state.load()) {
     case State::MDUZpp: [[fallthrough]];
     case State::MDUZsu: loop(); break;

--- a/src/mw/mdu/service.cpp
+++ b/src/mw/mdu/service.cpp
@@ -50,7 +50,7 @@ esp_err_t Service::socket(intf::http::Message& msg, State mdu_state) {
       state.compare_exchange_strong(expected, mdu_state)) {
     _queue.push(std::move(msg));
     LOGI_TASK_RESUME(task);
-    LOGI_TASK_RESUME(drv::out::track::mdu::task);
+    LOGI_TASK_CREATE(drv::out::track::mdu::task);
     return ESP_OK;
   }
   //

--- a/src/mw/mdu/service.hpp
+++ b/src/mw/mdu/service.hpp
@@ -31,7 +31,7 @@ public:
 
 private:
   esp_err_t socket(intf::http::Message& msg, State mdu_state);
-  void taskFunction(void*);
+  [[noreturn]] void taskFunction(void*);
   void loop();
   std::array<uint8_t, 2uz> transmit(std::vector<uint8_t> const& payload) const;
   void close();

--- a/src/mw/ota/service.cpp
+++ b/src/mw/ota/service.cpp
@@ -61,7 +61,7 @@ esp_err_t Service::socket(intf::http::Message& msg) {
 }
 
 /// \todo document
-void Service::taskFunction(void*) {
+[[noreturn]] void Service::taskFunction(void*) {
   switch (state.load()) {
     case State::OTA: loop(); break;
     default: assert(false); break;

--- a/src/mw/ota/service.cpp
+++ b/src/mw/ota/service.cpp
@@ -34,7 +34,7 @@ namespace mw::ota {
 /// \todo document
 /// \bug should this broadcast Z21 programming mode?
 Service::Service() {
-  task.create(ztl::make_trampoline(this, &Service::taskFunction));
+  task.function = ztl::make_trampoline(this, &Service::taskFunction);
 }
 
 /// \todo document
@@ -47,7 +47,7 @@ esp_err_t Service::socket(intf::http::Message& msg) {
       msg.type != HTTPD_WS_TYPE_CLOSE &&
       state.compare_exchange_strong(expected, State::OTA)) {
     _queue.push(std::move(msg));
-    LOGI_TASK_RESUME(task);
+    LOGI_TASK_CREATE(task);
     return ESP_OK;
   }
   //
@@ -62,13 +62,11 @@ esp_err_t Service::socket(intf::http::Message& msg) {
 
 /// \todo document
 void Service::taskFunction(void*) {
-  for (;;) {
-    LOGI_TASK_SUSPEND();
-    switch (state.load()) {
-      case State::OTA: loop(); break;
-      default: assert(false); break;
-    }
+  switch (state.load()) {
+    case State::OTA: loop(); break;
+    default: assert(false); break;
   }
+  LOGI_TASK_DESTROY();
 }
 
 /// \todo document

--- a/src/mw/ota/service.hpp
+++ b/src/mw/ota/service.hpp
@@ -38,7 +38,7 @@ public:
 
 private:
   // This gets called by FreeRTOS
-  void taskFunction(void*);
+  [[noreturn]] void taskFunction(void*);
 
   void loop();
   uint8_t write(std::vector<uint8_t> const& payload);

--- a/src/mw/ulf/dcc_ein/task_function.cpp
+++ b/src/mw/ulf/dcc_ein/task_function.cpp
@@ -170,7 +170,7 @@ void loop() {
 /// mem::nvs::Settings::getHttpReceiveTimeout "HTTP receive timeout", the \ref
 /// usb::rx_task_function "USB receive task" is created and this task destroys
 /// itself.
-void task_function(void*) {
+[[noreturn]] void task_function(void*) {
   // Switch to ULF_DCC_EIN mode, preload packets
   if (auto expected{State::Suspended};
       state.compare_exchange_strong(expected, State::ULF_DCC_EIN)) {

--- a/src/mw/ulf/dcc_ein/task_function.cpp
+++ b/src/mw/ulf/dcc_ein/task_function.cpp
@@ -168,7 +168,7 @@ void loop() {
 ///
 /// If no further senddcc string is received before the \ref
 /// mem::nvs::Settings::getHttpReceiveTimeout "HTTP receive timeout", the \ref
-/// usb::rx_task_function "USB receive task" is resumed and this task destroys
+/// usb::rx_task_function "USB receive task" is created and this task destroys
 /// itself.
 void task_function(void*) {
   // Switch to ULF_DCC_EIN mode, preload packets
@@ -183,7 +183,7 @@ void task_function(void*) {
   else
     intf::usb::transmit_not_ok();
 
-  LOGI_TASK_RESUME(intf::usb::rx_task);
+  LOGI_TASK_CREATE(intf::usb::rx_task);
   LOGI_TASK_DESTROY();
 }
 

--- a/src/mw/ulf/dcc_ein/task_function.cpp
+++ b/src/mw/ulf/dcc_ein/task_function.cpp
@@ -176,7 +176,7 @@ void task_function(void*) {
       state.compare_exchange_strong(expected, State::ULF_DCC_EIN)) {
     intf::usb::transmit_ok();
     send_idle_packets_to_back();
-    LOGI_TASK_RESUME(drv::out::track::dcc::task);
+    LOGI_TASK_CREATE(drv::out::track::dcc::task);
     loop();
   }
   // ... or not

--- a/src/mw/ulf/dcc_ein/task_function.hpp
+++ b/src/mw/ulf/dcc_ein/task_function.hpp
@@ -27,6 +27,6 @@
 namespace mw::ulf::dcc_ein {
 
 std::optional<::dcc::Packet> receive_dcc_packet();
-void task_function(void*);
+[[noreturn]] void task_function(void*);
 
 } // namespace mw::ulf::dcc_ein

--- a/src/mw/ulf/decup_ein/task_function.cpp
+++ b/src/mw/ulf/decup_ein/task_function.cpp
@@ -111,7 +111,7 @@ void loop() {
 /// its state is stored in a global variable \ref usb::rts.
 ///
 /// At the end of an upload, the \ref usb::rx_task_function "USB receive task"
-/// is resumed and this task destroys itself.
+/// is created and this task destroys itself.
 void task_function(void*) {
   // Switch to ULF_DECUP_EIN mode
   if (auto expected{State::Suspended};
@@ -124,7 +124,7 @@ void task_function(void*) {
   else
     intf::usb::transmit_not_ok();
 
-  LOGI_TASK_RESUME(intf::usb::rx_task);
+  LOGI_TASK_CREATE(intf::usb::rx_task);
   LOGI_TASK_DESTROY();
 }
 

--- a/src/mw/ulf/decup_ein/task_function.cpp
+++ b/src/mw/ulf/decup_ein/task_function.cpp
@@ -117,7 +117,7 @@ void task_function(void*) {
   if (auto expected{State::Suspended};
       state.compare_exchange_strong(expected, State::ULF_DECUP_EIN)) {
     intf::usb::transmit_ok();
-    LOGI_TASK_RESUME(drv::out::track::decup::task);
+    LOGI_TASK_CREATE(drv::out::track::decup::task);
     loop();
   }
   // ... or not

--- a/src/mw/ulf/decup_ein/task_function.cpp
+++ b/src/mw/ulf/decup_ein/task_function.cpp
@@ -112,7 +112,7 @@ void loop() {
 ///
 /// At the end of an upload, the \ref usb::rx_task_function "USB receive task"
 /// is created and this task destroys itself.
-void task_function(void*) {
+[[noreturn]] void task_function(void*) {
   // Switch to ULF_DECUP_EIN mode
   if (auto expected{State::Suspended};
       state.compare_exchange_strong(expected, State::ULF_DECUP_EIN)) {

--- a/src/mw/ulf/decup_ein/task_function.hpp
+++ b/src/mw/ulf/decup_ein/task_function.hpp
@@ -23,6 +23,6 @@
 
 namespace mw::ulf::decup_ein {
 
-void task_function(void*);
+[[noreturn]] void task_function(void*);
 
 } // namespace mw::ulf::decup_ein

--- a/src/mw/ulf/susiv2/task_function.cpp
+++ b/src/mw/ulf/susiv2/task_function.cpp
@@ -115,7 +115,7 @@ void loop() {
 /// and transmits them to drv::out::tx_message_buffer.
 ///
 /// Upon receiving an exit command the \ref usb::rx_task_function
-/// "USB receive task" is resumed and this task destroys itself.
+/// "USB receive task" is created and this task destroys itself.
 void task_function(void*) {
   // Switch to ULF_SUSIV2 mode
   if (auto expected{State::Suspended};
@@ -128,7 +128,7 @@ void task_function(void*) {
   else
     intf::usb::transmit_not_ok();
 
-  LOGI_TASK_RESUME(intf::usb::rx_task);
+  LOGI_TASK_CREATE(intf::usb::rx_task);
   LOGI_TASK_DESTROY();
 }
 

--- a/src/mw/ulf/susiv2/task_function.cpp
+++ b/src/mw/ulf/susiv2/task_function.cpp
@@ -116,7 +116,7 @@ void loop() {
 ///
 /// Upon receiving an exit command the \ref usb::rx_task_function
 /// "USB receive task" is created and this task destroys itself.
-void task_function(void*) {
+[[noreturn]] void task_function(void*) {
   // Switch to ULF_SUSIV2 mode
   if (auto expected{State::Suspended};
       state.compare_exchange_strong(expected, State::ULF_SUSIV2)) {

--- a/src/mw/ulf/susiv2/task_function.cpp
+++ b/src/mw/ulf/susiv2/task_function.cpp
@@ -121,7 +121,7 @@ void task_function(void*) {
   if (auto expected{State::Suspended};
       state.compare_exchange_strong(expected, State::ULF_SUSIV2)) {
     intf::usb::transmit_ok();
-    LOGI_TASK_RESUME(drv::out::zusi::task);
+    LOGI_TASK_CREATE(drv::out::zusi::task);
     loop();
   }
   // ... or not

--- a/src/mw/ulf/susiv2/task_function.hpp
+++ b/src/mw/ulf/susiv2/task_function.hpp
@@ -23,6 +23,6 @@
 
 namespace mw::ulf::susiv2 {
 
-void task_function(void*);
+[[noreturn]] void task_function(void*);
 
 } // namespace mw::ulf::susiv2

--- a/src/mw/z21/service.cpp
+++ b/src/mw/z21/service.cpp
@@ -73,7 +73,7 @@ esp_err_t Service::socket(intf::http::Message& msg) {
 }
 
 /// \todo document
-void Service::taskFunction(void*) {
+[[noreturn]] void Service::taskFunction(void*) {
   std::array<uint8_t, Z21_MAX_PAYLOAD_SIZE> stack;
   sockaddr_in dest_addr_ip4;
   socklen_t socklen{sizeof(dest_addr_ip4)};

--- a/src/mw/z21/service.cpp
+++ b/src/mw/z21/service.cpp
@@ -288,7 +288,7 @@ bool Service::trackPower(bool on, State dcc_state) {
           vTaskDelay(pdMS_TO_TICKS(task.timeout));
         if (auto expected{State::Suspended};
             state.compare_exchange_strong(expected, dcc_state))
-          LOGI_TASK_RESUME(dcc::task);
+          LOGI_TASK_CREATE(dcc::task);
         else assert(false);
         [[fallthrough]];
 

--- a/src/mw/z21/service.cpp
+++ b/src/mw/z21/service.cpp
@@ -284,7 +284,7 @@ bool Service::trackPower(bool on, State dcc_state) {
 
       //
       case State::Suspended:
-        while (eTaskGetState(drv::out::track::dcc::task.handle) != eSuspended)
+        while (xTaskGetHandle("drv::out::track::dcc"))
           vTaskDelay(pdMS_TO_TICKS(task.timeout));
         if (auto expected{State::Suspended};
             state.compare_exchange_strong(expected, dcc_state))

--- a/src/mw/z21/service.hpp
+++ b/src/mw/z21/service.hpp
@@ -39,7 +39,7 @@ public:
 
 private:
   // This gets called by FreeRTOS
-  void taskFunction(void*);
+  [[noreturn]] void taskFunction(void*);
 
   //
   void transmit(z21::Socket const& sock,

--- a/src/mw/zusi/service.cpp
+++ b/src/mw/zusi/service.cpp
@@ -26,7 +26,7 @@ using ::ulf::susiv2::ack, ::ulf::susiv2::nak;
 
 /// \todo document
 Service::Service() {
-  task.create(ztl::make_trampoline(this, &Service::taskFunction));
+  task.function = ztl::make_trampoline(this, &Service::taskFunction);
 }
 
 /// \todo document
@@ -40,8 +40,7 @@ esp_err_t Service::socket(intf::http::Message& msg) {
       msg.type != HTTPD_WS_TYPE_CLOSE &&
       state.compare_exchange_strong(expected, State::ZUSI)) {
     _queue.push(std::move(msg));
-    LOGI_TASK_RESUME(task);
-    LOGI_TASK_CREATE(drv::out::zusi::task);
+    LOGI_TASKS_CREATE(task, drv::out::zusi::task);
     return ESP_OK;
   }
   //
@@ -56,13 +55,11 @@ esp_err_t Service::socket(intf::http::Message& msg) {
 
 /// \todo document
 void Service::taskFunction(void*) {
-  for (;;) {
-    LOGI_TASK_SUSPEND();
-    switch (state.load()) {
-      case State::ZUSI: loop(); break;
-      default: assert(false); break;
-    }
+  switch (state.load()) {
+    case State::ZUSI: loop(); break;
+    default: assert(false); break;
   }
+  LOGI_TASK_DESTROY();
 }
 
 /// \todo document

--- a/src/mw/zusi/service.cpp
+++ b/src/mw/zusi/service.cpp
@@ -41,7 +41,7 @@ esp_err_t Service::socket(intf::http::Message& msg) {
       state.compare_exchange_strong(expected, State::ZUSI)) {
     _queue.push(std::move(msg));
     LOGI_TASK_RESUME(task);
-    LOGI_TASK_RESUME(drv::out::zusi::task);
+    LOGI_TASK_CREATE(drv::out::zusi::task);
     return ESP_OK;
   }
   //

--- a/src/mw/zusi/service.cpp
+++ b/src/mw/zusi/service.cpp
@@ -54,7 +54,7 @@ esp_err_t Service::socket(intf::http::Message& msg) {
 }
 
 /// \todo document
-void Service::taskFunction(void*) {
+[[noreturn]] void Service::taskFunction(void*) {
   switch (state.load()) {
     case State::ZUSI: loop(); break;
     default: assert(false); break;

--- a/src/mw/zusi/service.hpp
+++ b/src/mw/zusi/service.hpp
@@ -33,7 +33,7 @@ public:
   esp_err_t socket(intf::http::Message& msg);
 
 private:
-  void taskFunction(void*);
+  [[noreturn]] void taskFunction(void*);
   void loop();
   ::ulf::susiv2::Response transmit(std::vector<uint8_t> const& payload) const;
   void close();

--- a/tests/freertos_helpers.cpp
+++ b/tests/freertos_helpers.cpp
@@ -1,11 +1,5 @@
 #include "freertos_helpers.hpp"
 
-void task_delete_clear_handle(TaskHandle_t& task_handle) {
-  if (!task_handle) return;
-  vTaskDelete(task_handle);
-  task_handle = NULL;
-}
-
 void stream_buffer_delete_clear_handle(
   StreamBufferHandle_t& stream_buffer_handle) {
   if (!stream_buffer_handle) return;

--- a/tests/freertos_helpers.hpp
+++ b/tests/freertos_helpers.hpp
@@ -11,8 +11,6 @@ auto task_create_stub(TaskHandle_t& task_handle) {
     Unique, NULL, 4096uz, NULL, tskIDLE_PRIORITY, &task_handle);
 }
 
-void task_delete_clear_handle(TaskHandle_t& task_handle);
-
 void stream_buffer_delete_clear_handle(
   StreamBufferHandle_t& stream_buffer_handle);
 

--- a/tests/intf/usb/usb.cpp
+++ b/tests/intf/usb/usb.cpp
@@ -1,0 +1,19 @@
+#include "intf/usb/rx_task_function.hpp"
+#include "usb_test.hpp"
+
+TEST_F(UsbTest, no_service_tasks_active) {
+  EXPECT_FALSE(intf::usb::any_service_task_active());
+}
+
+TEST_F(UsbTest, all_service_tasks_active) {
+  mw::ulf::dcc_ein::task.create([](void*) {
+    for (;;) vTaskDelay(pdMS_TO_TICKS(1000u));
+  });
+  mw::ulf::decup_ein::task.create([](void*) {
+    for (;;) vTaskDelay(pdMS_TO_TICKS(1000u));
+  });
+  mw::ulf::susiv2::task.create([](void*) {
+    for (;;) vTaskDelay(pdMS_TO_TICKS(1000u));
+  });
+  EXPECT_TRUE(intf::usb::any_service_task_active());
+}

--- a/tests/intf/usb/usb_test.cpp
+++ b/tests/intf/usb/usb_test.cpp
@@ -1,22 +1,16 @@
 #include "usb_test.hpp"
 #include "freertos_helpers.hpp"
 
-// Create stream buffers and task stubs
+// Create stream buffers
 UsbTest::UsbTest() {
   intf::usb::rx_stream_buffer.handle =
     xStreamBufferCreate(intf::usb::rx_stream_buffer.size, 1uz);
   intf::usb::tx_stream_buffer.handle =
     xStreamBufferCreate(intf::usb::tx_stream_buffer.size, 1uz);
-  task_create_stub(mw::ulf::dcc_ein::task.handle);
-  task_create_stub(mw::ulf::decup_ein::task.handle);
-  task_create_stub(mw::ulf::susiv2::task.handle);
 }
 
-// Delete stream buffers and task stubs
+// Delete stream buffers
 UsbTest::~UsbTest() {
   stream_buffer_delete_clear_handle(intf::usb::rx_stream_buffer.handle);
   stream_buffer_delete_clear_handle(intf::usb::tx_stream_buffer.handle);
-  task_delete_clear_handle(mw::ulf::dcc_ein::task.handle);
-  task_delete_clear_handle(mw::ulf::decup_ein::task.handle);
-  task_delete_clear_handle(mw::ulf::susiv2::task.handle);
 }


### PR DESCRIPTION
All tasks are now created and deleted if needed and no longer suspended and resumed. This opens up the option to share stack between tasks. For some tasks (e.g. the ones in `drv::out` this already happens.