### PR TITLE
Mainly design changes see description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ managed_components
 dependencies.lock
 sdkconfig
 sdkconfig.old
+.bash_aliases

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,7 +1,5 @@
 {
   "{src}/**/*.{cpp,hpp}": [
-    "// Copyright (C) 2025 Vincent Hamp",
-    "//",
     "// This program is free software: you can redistribute it and/or modify",
     "// it under the terms of the GNU General Public License as published by",
     "// the Free Software Foundation, either version 3 of the License, or",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ FetchContent_Declare(
   GIT_TAG v0.9.5)
 FetchContent_MakeAvailable(CMakeModules)
 
+set(OPENREMISE_FRONTEND_SOURCE_DIR
+    ""
+    CACHE STRING "Overrides the frontend source code directory")
+
 set(EXTRA_COMPONENT_DIRS src)
 if(IDF_TARGET STREQUAL linux)
   # Don't change COMPONENTS on ESP32* targets, it removes a shit ton of defaults
@@ -28,17 +32,24 @@ if(ESP_PLATFORM
    AND NOT IDF_TARGET STREQUAL linux
    AND NOT EXISTS ${Frontend_BINARY_DIR})
 
-  # Build from devel branch at config time
-  if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    cpmaddpackage(
-      NAME
-      Frontend
-      GITHUB_REPOSITORY
-      "OpenRemise/Frontend"
-      GIT_TAG
-      devel
-      DOWNLOAD_ONLY
-      TRUE)
+  # Build from local repo or devel branch at config time
+  if(NOT ${OPENREMISE_FRONTEND_SOURCE_DIR} STREQUAL "" OR CMAKE_BUILD_TYPE
+                                                          STREQUAL Debug)
+    if(OPENREMISE_FRONTEND_SOURCE_DIR)
+      cpmaddpackage(NAME Frontend SOURCE_DIR ${OPENREMISE_FRONTEND_SOURCE_DIR}
+                    DOWNLOAD_ONLY TRUE)
+    else()
+      cpmaddpackage(
+        NAME
+        Frontend
+        GITHUB_REPOSITORY
+        "OpenRemise/Frontend"
+        GIT_TAG
+        devel
+        DOWNLOAD_ONLY
+        TRUE)
+    endif()
+
     execute_process(
       COMMAND ${CMAKE_COMMAND} -B${Frontend_BINARY_DIR}
       WORKING_DIRECTORY ${Frontend_SOURCE_DIR} COMMAND_ECHO STDOUT
@@ -48,7 +59,7 @@ if(ESP_PLATFORM
               COMMAND_ECHO STDOUT COMMAND_ERROR_IS_FATAL ANY)
     set(FRONTEND_WEB_DIR ${Frontend_BINARY_DIR}/web)
 
-    # .. or use pre-built
+    # ... or use pre-built official release
   elseif(CMAKE_BUILD_TYPE STREQUAL Release)
     cpmaddpackage(
       NAME

--- a/nvs.csv
+++ b/nvs.csv
@@ -11,6 +11,7 @@ sta_netmask,data,binary,""
 sta_gateway,data,binary,""
 http_rx_timeout,data,u8,5
 http_tx_timeout,data,u8,5
+http_exit_msg,data,u8,1
 cur_lim,data,u8,3
 cur_lim_serv,data,u8,1
 cur_sc_time,data,u8,100

--- a/src/intf/usb/init.cpp
+++ b/src/intf/usb/init.cpp
@@ -70,12 +70,25 @@ esp_err_t init() {
   rx_task.create(rx_task_function);
   tx_task.create(tx_task_function);
 
+/*
   static constexpr tinyusb_config_t tusb_cfg{.device_descriptor = NULL,
                                              .string_descriptor = NULL,
                                              .external_phy = false,
                                              .configuration_descriptor = NULL,
                                              .self_powered = true,
                                              .vbus_monitor_io = vbus_gpio_num};
+*/
+  static constexpr tinyusb_config_t tusb_cfg{ .device_descriptor = NULL,
+                                              .string_descriptor = NULL,
+                                              .external_phy = false,
+                                              #if (TUD_OPT_HIGH_SPEED)
+                                                  .fs_configuration_descriptor = NULL,
+                                                  .hs_configuration_descriptor = NULL,
+                                                  .qualifier_descriptor = NULL,
+                                              #else
+                                                  .configuration_descriptor = NULL,
+                                              #endif // TUD_OPT_HIGH_SPEED
+                                            };
   ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
 
   static constexpr tinyusb_config_cdcacm_t acm_cfg{

--- a/src/mem/nvs/doxygen.hpp
+++ b/src/mem/nvs/doxygen.hpp
@@ -65,6 +65,7 @@ namespace mem::nvs {
 /// | Range of IP addresses in the network                                                                                                             | sta_gateway     | Binary | -   | -   | ""       |
 /// | Timeout for receiving [HTTP](https://en.wikipedia.org/wiki/HTTP) requests (also used for USB)                                                    | http_rx_timeout | u8     | 5   | 60  | 5        |
 /// | Timeout for transmitting HTTP response                                                                                                           | http_tx_timeout | u8     | 5   | 60  | 5        |
+/// | Display a query when leaving the page                                                                                                            | http_exit_msg   | u8     | 0   | 1   | 1        |
 /// | Current limit in [DCC](https://github.com/ZIMO-Elektronik/DCC) operation mode                                                                    | cur_lim         | u8     | 0   | 3   | 3        |
 /// | Current limit in DCC service mode                                                                                                                | cur_lim_serv    | u8     | 0   | 3   | 1        |
 /// | Time after which an overcurrent is considered a short circuit                                                                                    | cur_sc_time     | u8     | 20  | 240 | 100      |

--- a/src/mem/nvs/init.cpp
+++ b/src/mem/nvs/init.cpp
@@ -65,6 +65,8 @@ esp_err_t init() {
       nvs.setHttpReceiveTimeout(5u);
     if (nvs.find("http_tx_timeout") == ESP_ERR_NVS_NOT_FOUND)
       nvs.setHttpTransmitTimeout(5u);
+    if (nvs.find("http_exit_msg") == ESP_ERR_NVS_NOT_FOUND)
+      nvs.setHttpExitMessage(true);
     if (nvs.find("cur_lim") == ESP_ERR_NVS_NOT_FOUND)
       nvs.setCurrentLimit(drv::out::track::CurrentLimit::_4100mA);
     if (nvs.find("cur_lim_serv") == ESP_ERR_NVS_NOT_FOUND)

--- a/src/mem/nvs/settings.cpp
+++ b/src/mem/nvs/settings.cpp
@@ -245,6 +245,26 @@ esp_err_t Settings::setHttpTransmitTimeout(uint8_t value) {
                                      : ESP_ERR_INVALID_ARG;
 }
 
+/// Get HTTP exit message
+///
+/// \return HTTP exit message
+bool Settings::getHttpExitMessage() const {
+  return static_cast<bool>(getU8("http_exit_msg"));
+}
+
+/// Set HTTP exit message
+///
+/// \param  value                         HTTP exit message
+/// \retval ESP_OK                        Value was set successfully
+/// \retval ESP_FAIL                      Internal error
+/// \retval ESP_ERR_NVS_INVALID_NAME      Key name doesn't satisfy constraints
+/// \retval ESP_ERR_NVS_NOT_ENOUGH_SPACE  Not enough space
+/// \retval ESP_ERR_NVS_REMOVE_FAILED     Value wasn't updated because flash
+///                                       write operation has failed
+esp_err_t Settings::setHttpExitMessage(bool value) {
+  return setU8("http_exit_msg", value);
+}
+
 /// Get current limit
 ///
 /// \return Current limit

--- a/src/mem/nvs/settings.hpp
+++ b/src/mem/nvs/settings.hpp
@@ -68,6 +68,9 @@ public:
   uint8_t getHttpTransmitTimeout() const;
   esp_err_t setHttpTransmitTimeout(uint8_t value);
 
+  bool getHttpExitMessage() const;
+  esp_err_t setHttpExitMessage(bool value);
+
   drv::out::track::CurrentLimit getCurrentLimit() const;
   esp_err_t setCurrentLimit(drv::out::track::CurrentLimit value);
 


### PR DESCRIPTION
False Short Circuit Notification:
A function has been integrated to check whether the internal web server can be reached (displayed at the top right). If the connection is interrupted, the short circuit notification will not be displayed.

Design Changes:
All screens have been given a title.
A dividing line is displayed below the title on the wide design. Settings Screen
All categories have been organized into tiles that can be expanded/collapsed.

A new "expand/collapse all" button has been added at the top next to the "Default" button.

Settings:
Two new settings have been added.
Timeout for connection loss.
ExitMessage: This notification should be displayed when leaving the page.

	neue Datei:     .bash_aliases
	geändert:       .gitignore
	geändert:       CMakeLists.txt
	geändert:       CMakePresets.json
	neue Datei:     frontend_dir.example.cmake
	geändert:       nvs.csv
	geändert:       src/intf/http/sta/server.cpp
	geändert:       src/intf/usb/init.cpp
	geändert:       src/mem/nvs/doxygen.hpp
	geändert:       src/mem/nvs/init.cpp
	geändert:       src/mem/nvs/settings.cpp
	geändert:       src/mem/nvs/settings.hpp