### PR TITLE
Turnouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           mkdir -p ~/esp
           cd ~/esp
-          git clone -b fix_ws_recv --recursive https://github.com/higaski/esp-idf.git
+          git clone -b v5.5.1 --recursive https://github.com/espressif/esp-idf.git
           cd ~/esp/esp-idf
           ./install.sh esp32s3
       - run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir -p ~/esp
           cd ~/esp
-          git clone -b fix_ws_recv --recursive https://github.com/higaski/esp-idf.git
+          git clone -b v5.5.1 --recursive https://github.com/espressif/esp-idf.git
           cd ~/esp/esp-idf
           ./install.sh esp32s3
       - run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       pre-build: |
         sudo apt update -y
         sudo apt install -y libbsd-dev ninja-build
-      esp_idf_version: master
+      esp_idf_version: v5.5.1
       target: linux
       command: |
         cmake --preset "Tests"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if(ESP_PLATFORM
         GITHUB_REPOSITORY
         "OpenRemise/Frontend"
         GIT_TAG
-        devel
+        turnouts
         DOWNLOAD_ONLY
         TRUE)
     endif()

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,5 +1,5 @@
 # This file was generated using idf.py save-defconfig. It can be edited manually.
-# Espressif IoT Development Framework (ESP-IDF) 5.5.0 Project Minimal Configuration
+# Espressif IoT Development Framework (ESP-IDF) 5.5.1 Project Minimal Configuration
 #
 CONFIG_IDF_TARGET="esp32s3"
 CONFIG_ESPTOOLPY_OCT_FLASH=y

--- a/src/drv/out/track/dcc/task_function.cpp
+++ b/src/drv/out/track/dcc/task_function.cpp
@@ -56,7 +56,7 @@ struct Offsets {
 /// \bug DCC/RailCom timings seem to get worse when the DCC tasks runs the
 /// second time?
 consteval Offsets make_offsets() {
-  static_assert(CONFIG_IDF_INIT_VERSION == "5.5.0"sv);
+  static_assert(CONFIG_IDF_INIT_VERSION == "5.5.1"sv);
 
   return {
 #if defined(CONFIG_COMPILER_OPTIMIZATION_DEBUG)

--- a/src/idf_component.yml
+++ b/src/idf_component.yml
@@ -1,9 +1,9 @@
 dependencies:
-  idf: "5.5.0"
+  idf: "5.5.1"
   bblanchon/arduinojson:
-    version: "7.4.1"
+    version: "7.4.2"
   espressif/esp_tinyusb:
-    version: "1.7.4"
+    version: "1.7.6~1"
     rules:
       - if: "target != linux"
   espressif/tinyusb:
@@ -15,10 +15,10 @@ dependencies:
     rules:
       - if: "target != linux"
   zimo-elektronik/dcc:
-    version: "0.41.1"
+    version: "0.44.1"
   zimo-elektronik/decup:
     version: "0.1.4"
   zimo-elektronik/mdu:
-    version: "0.18.1"
+    version: "0.19.0"
   zimo-elektronik/z21:
     version: "0.3.2"

--- a/src/intf/http/doxygen.hpp
+++ b/src/intf/http/doxygen.hpp
@@ -25,14 +25,67 @@ namespace intf::http {
 
 /// \page page_intf_http HTTP
 /// \details \tableofcontents
-///
-/// https://jsonviewer.stack.hu
-///
-/// \todo document HTTP page
+/// The HTTP module contains the implementation of the web server. Depending on
+/// the operating mode (access point or station), either a server for the
+/// captive portal or one for the REST APIs is created. Which server is
+/// ultimately started depends on whether a network SSID is stored in the
+/// settings. If no settings are available yet, the access point server is
+/// started, otherwise the station server is started.
 ///
 /// \section section_intf_http_ap Access Point
+/// The access point server provides the [captive
+/// portal](https://github.com/OpenRemise/Firmware/raw/master/src/intf/http/ap/captive_portal.html)
+/// for initial network configuration. Two endpoints are created for this
+/// purpose:
+/// - /save/
+///   - POST
+/// - /*
+///   - GET
+///
+/// \subsection subsection_intf_http_ap_wildcard /*
+/// The wildcard GET endpoint redirects all requests to the captive portal. The
+/// string containing the complete HTML code is generated at runtime using
+/// [std::format_to_n](https://en.cppreference.com/w/cpp/utility/format/format_to_n.html).
+/// In addition to a number of (pre)settings, it also contains a list of
+/// available WiFi networks.
+///
+/// \subsection subsection_intf_http_ap_save /save/
+/// The POST endpoint receives the settings of the captive portal when saving in
+/// the form of query parameters. The settings are stored in the NVS namespace
+/// `settings`. Afterwards the board reboots.
 ///
 /// \section section_intf_http_sta Station
+/// The server for station mode provides a whole range of different endpoints
+/// that can be used in normal operation.
+/// - /dcc/
+///   - GET
+///   - POST
+/// - /dcc/locos/
+///   - DELETE
+///   - GET
+///   - PUT
+/// - /dcc/turnouts/
+///   - DELETE
+///   - GET
+///   - PUT
+/// - /settings/
+///   - GET
+///   - POST
+/// - /sys/
+///   - GET
+/// - /*
+///   - GET
+///
+/// WebSockets?
+///
+/// \subsection subsection_intf_http_sta_endpoints Endpoints
+/// The Endpoints class allows you to set up subscriptions to different
+/// endpoints. For such a subscription, the request type and endpoint name must
+/// be specified. Furthermore, a distinction is made between synchronous (HTTP)
+/// and asynchronous (WebSocket) connections.
+///
+/// Both subscription types are stored in a std::map with a custom key
+/// comparator.
 ///
 /// <div class="section_buttons">
 /// | Previous       | Next                |

--- a/src/intf/http/sta/server.cpp
+++ b/src/intf/http/sta/server.cpp
@@ -72,6 +72,24 @@ Server::Server() {
   httpd_register_uri_handler(handle, &uri);
 
   //
+  uri = {.uri = "/dcc/turnouts/*",
+         .method = HTTP_GET,
+         .handler = ztl::make_trampoline(this, &Server::getHandler)};
+  httpd_register_uri_handler(handle, &uri);
+
+  //
+  uri = {.uri = "/dcc/turnouts/*",
+         .method = HTTP_PUT,
+         .handler = ztl::make_trampoline(this, &Server::putPostHandler)};
+  httpd_register_uri_handler(handle, &uri);
+
+  //
+  uri = {.uri = "/dcc/turnouts/*",
+         .method = HTTP_DELETE,
+         .handler = ztl::make_trampoline(this, &Server::deleteHandler)};
+  httpd_register_uri_handler(handle, &uri);
+
+  //
   uri = {.uri = "/dcc/*",
          .method = HTTP_GET,
          .handler = ztl::make_trampoline(this, &Server::getHandler)};

--- a/src/intf/usb/init.cpp
+++ b/src/intf/usb/init.cpp
@@ -70,16 +70,12 @@ esp_err_t init() {
   rx_task.create(rx_task_function);
   tx_task.create(tx_task_function);
 
-  static constexpr tinyusb_config_t tusb_cfg{
-    .device_descriptor = NULL,
-    .string_descriptor = NULL,
-    .external_phy = false,
-    .configuration_descriptor = NULL,
-    /// \bug Currently can cause issues on Windows 11
-    /// https://github.com/OpenRemise/Firmware/issues/47
-    //.self_powered = true,
-    //.vbus_monitor_io = vbus_gpio_num
-  };
+  static constexpr tinyusb_config_t tusb_cfg{.device_descriptor = NULL,
+                                             .string_descriptor = NULL,
+                                             .external_phy = false,
+                                             .configuration_descriptor = NULL,
+                                             .self_powered = true,
+                                             .vbus_monitor_io = vbus_gpio_num};
   ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
 
   static constexpr tinyusb_config_cdcacm_t acm_cfg{

--- a/src/mem/nvs/locos.cpp
+++ b/src/mem/nvs/locos.cpp
@@ -45,9 +45,7 @@ mw::dcc::NvLocoBase Locos::get(std::string const& key) const {
     LOGE("Deserialization failed %s", err.c_str());
     return {};
   }
-  mw::dcc::NvLocoBase loco;
-  loco.fromJsonDocument(doc);
-  return loco;
+  return mw::dcc::NvLocoBase{doc};
 }
 
 /// Set loco from address

--- a/src/mem/nvs/turnouts.cpp
+++ b/src/mem/nvs/turnouts.cpp
@@ -39,7 +39,13 @@ mw::dcc::NvTurnoutBase Turnouts::get(dcc::Address::value_type addr) const {
 /// \param  addr  key
 /// \return Turnout
 mw::dcc::NvTurnoutBase Turnouts::get(std::string const& key) const {
-  return {};
+  auto const json{getBlob(key)};
+  JsonDocument doc;
+  if (auto const err{deserializeJson(doc, json)}) {
+    LOGE("Deserialization failed %s", err.c_str());
+    return {};
+  }
+  return mw::dcc::NvTurnoutBase{doc};
 }
 
 /// Set turnout from address
@@ -71,7 +77,11 @@ esp_err_t Turnouts::set(dcc::Address::value_type addr,
 /// \retval ESP_ERR_NVS_VALUE_TOO_LONG    String value is too long
 esp_err_t Turnouts::set(std::string const& key,
                         mw::dcc::NvTurnoutBase const& turnout) {
-  return {};
+  auto const doc{turnout.toJsonDocument()};
+  std::string json;
+  json.reserve(1024uz);
+  if (!serializeJson(doc, json)) assert(false);
+  return setBlob(key, json);
 }
 
 /// Erase turnout from address

--- a/src/mw/dcc/init.cpp
+++ b/src/mw/dcc/init.cpp
@@ -38,6 +38,18 @@ esp_err_t init() {
       service,
       &Service::locosPutRequest);
     intf::http::sta::server->subscribe(
+      {.uri = "/dcc/turnouts/", .method = HTTP_DELETE},
+      service,
+      &Service::turnoutsDeleteRequest);
+    intf::http::sta::server->subscribe(
+      {.uri = "/dcc/turnouts/", .method = HTTP_GET},
+      service,
+      &Service::turnoutsGetRequest);
+    intf::http::sta::server->subscribe(
+      {.uri = "/dcc/turnouts/", .method = HTTP_PUT},
+      service,
+      &Service::turnoutsPutRequest);
+    intf::http::sta::server->subscribe(
       {.uri = "/dcc/", .method = HTTP_GET}, service, &Service::getRequest);
     intf::http::sta::server->subscribe(
       {.uri = "/dcc/", .method = HTTP_POST}, service, &Service::postRequest);

--- a/src/mw/dcc/loco.cpp
+++ b/src/mw/dcc/loco.cpp
@@ -19,16 +19,18 @@
 namespace mw::dcc {
 
 /// \todo document
+NvLocoBase::NvLocoBase(JsonDocument const& doc) { fromJsonDocument(doc); }
+
+/// \todo document
 void NvLocoBase::fromJsonDocument(JsonDocument const& doc) {
   if (JsonVariantConst v{doc["name"]}; v.is<std::string>())
     name = v.as<std::string>();
 
-  if (JsonVariantConst v{doc["mode"]}; v.is<z21::LocoInfo::Mode>())
-    if (v.as<z21::LocoInfo::Mode>() != z21::LocoInfo::Mode::DCC)
-      LOGE("Can't set mode to anything but DCC");
+  if (JsonVariantConst v{doc["mode"]}; v.is<Mode>())
+    if (v.as<Mode>() != Mode::DCC) LOGE("Can't set mode to anything but DCC");
 
-  if (JsonVariantConst v{doc["speed_steps"]}; v.is<z21::LocoInfo::SpeedSteps>())
-    speed_steps = v.as<z21::LocoInfo::SpeedSteps>();
+  if (JsonVariantConst v{doc["speed_steps"]}; v.is<SpeedSteps>())
+    speed_steps = v.as<SpeedSteps>();
 }
 
 /// \todo document
@@ -51,9 +53,7 @@ void Loco::fromJsonDocument(JsonDocument const& doc) {
 
   if (JsonVariantConst v{doc["f31_0"]}; v.is<uint32_t>()) f31_0 = v;
 
-  if (JsonVariantConst v{doc["bidi"]}; v.is<JsonObject>()) {
-    JsonObjectConst obj{v.as<JsonObjectConst>()};
-
+  if (JsonObjectConst obj{doc["bidi"].as<JsonObjectConst>()}) {
     if (JsonVariantConst v{obj["receive_counter"]}; v.is<uint32_t>())
       bidi.receive_counter = v.as<uint32_t>();
 
@@ -77,7 +77,7 @@ JsonDocument Loco::toJsonDocument() const {
   doc["rvvvvvvv"] = rvvvvvvv;
   doc["f31_0"] = f31_0;
 
-  JsonObject obj{doc["bidi"].to<JsonObject>()};
+  JsonObject obj{doc.createNestedObject("bidi")};
   obj["receive_counter"] = bidi.receive_counter;
   obj["error_counter"] = bidi.error_counter;
   obj["options"] = bidi.options;

--- a/src/mw/dcc/loco.hpp
+++ b/src/mw/dcc/loco.hpp
@@ -30,8 +30,12 @@ namespace z21 = ::z21;
 
 /// Non-volatile base
 struct NvLocoBase : z21::LocoInfo {
+  constexpr NvLocoBase() = default;
+  explicit NvLocoBase(JsonDocument const& doc);
+
   void fromJsonDocument(JsonDocument const& doc);
   JsonDocument toJsonDocument() const;
+
   std::string name{};
 };
 

--- a/src/mw/dcc/service.hpp
+++ b/src/mw/dcc/service.hpp
@@ -43,6 +43,11 @@ public:
   intf::http::Response locosDeleteRequest(intf::http::Request const& req);
   intf::http::Response locosPutRequest(intf::http::Request const& req);
 
+  //
+  intf::http::Response turnoutsGetRequest(intf::http::Request const& req);
+  intf::http::Response turnoutsDeleteRequest(intf::http::Request const& req);
+  intf::http::Response turnoutsPutRequest(intf::http::Request const& req);
+
 private:
   // This gets called by FreeRTOS
   [[noreturn]] void taskFunction(void*);
@@ -110,7 +115,8 @@ private:
   uint8_t _priority_count{Loco::min_priority};
 
   // Settings
-  uint8_t _dcc_loco_flags{};
+  uint8_t _loco_flags{};
+  uint8_t _accy_flags{};
   uint8_t _programming_type{};
   uint8_t _program_packet_count{};
   bool _bit_verify_to_1{};

--- a/src/mw/dcc/turnout.hpp
+++ b/src/mw/dcc/turnout.hpp
@@ -30,9 +30,44 @@ namespace z21 = ::z21;
 
 /// Non-volatile base
 struct NvTurnoutBase : z21::TurnoutInfo {
+  constexpr NvTurnoutBase() = default;
+  explicit NvTurnoutBase(JsonDocument const& doc);
+
   void fromJsonDocument(JsonDocument const& doc);
   JsonDocument toJsonDocument() const;
+
   std::string name{};
+  enum Type : uint16_t {
+    // Special
+    Unknown,
+    Hidden,
+    Custom,
+
+    // Track (move)
+    TurnoutRight = 256u,
+    TurnoutLeft,
+    TurnoutY,
+    Turnout3Way,
+
+    // Signal (guide)
+    Signal2Aspects = 512u,
+    Signal3Aspects,
+    Signal4Aspects,
+    SignalBlocking,
+    SignalSemaphore,
+
+    // Scenery (world)
+    Light = 768u,
+    CrossingGate,
+    Relay,
+
+    /// \todo Railway signals of actual countries?
+    AT = 1024u,
+  } type{};
+  struct Group {
+    std::vector<Address::value_type> addresses{};
+    std::vector<std::vector<Position>> states{};
+  } group{};
 };
 
 /// Actual object with volatile and non-volatile stuff

--- a/src/mw/roco/z21/service.cpp
+++ b/src/mw/roco/z21/service.cpp
@@ -216,35 +216,32 @@ void Service::locoMode(uint16_t loco_addr, z21::LocoInfo::Mode mode) {
 
 /// \todo document
 z21::TurnoutInfo Service::turnoutInfo(uint16_t accy_addr) {
-  LOGW("TODO IMPLEMENTED");
-  return {};
+  return _dcc_service->turnoutInfo(accy_addr);
 }
 
 /// \todo document
 z21::AccessoryInfo Service::accessoryInfo(uint16_t accy_addr) {
-  LOGW("TODO IMPLEMENTED");
-  return {};
+  return _dcc_service->accessoryInfo(accy_addr);
 }
 
 /// \todo document
 void Service::turnout(uint16_t accy_addr, bool p, bool a, bool q) {
-  LOGW("TODO IMPLEMENTED");
+  _dcc_service->turnout(accy_addr, p, a, q);
 }
 
 /// \todo document
 void Service::accessory(uint16_t accy_addr, uint8_t dddddddd) {
-  LOGW("TODO IMPLEMENTED");
+  _dcc_service->accessory(accy_addr, dddddddd);
 }
 
 /// \todo document
 z21::TurnoutInfo::Mode Service::turnoutMode(uint16_t accy_addr) {
-  LOGW("TODO IMPLEMENTED");
-  return {};
+  return _dcc_service->turnoutMode(accy_addr);
 }
 
 /// \todo document
 void Service::turnoutMode(uint16_t accy_addr, z21::TurnoutInfo::Mode mode) {
-  LOGW("TODO IMPLEMENTED");
+  _dcc_service->turnoutMode(accy_addr, mode);
 }
 
 /// \todo document

--- a/tests/mw/dcc/loco.cpp
+++ b/tests/mw/dcc/loco.cpp
@@ -9,11 +9,11 @@ TEST_F(DccTest, loco_to_base_to_json) {
   std::string json;
   json.reserve(1024uz);
   serializeJson(doc, json);
-  EXPECT_EQ(json, "{\"name\":\"BR85\",\"mode\":0,\"speed_steps\":2}");
+  EXPECT_EQ(json, R"({"name":"BR85","mode":0,"speed_steps":2})");
 }
 
 TEST_F(DccTest, json_to_base_to_loco) {
-  std::string json{"{\"name\":\"BR85\",\"speed_steps\":2}"};
+  std::string json{R"({"name":"BR85","speed_steps":2})"};
   JsonDocument doc;
   deserializeJson(doc, json);
   mw::dcc::NvLocoBase base;
@@ -29,27 +29,25 @@ TEST_F(DccTest, loco_to_json) {
   loco.name = "Reihe 2190";
   loco.rvvvvvvv = 1u << 7u | 42u;
   loco.f31_0 = 1u << 3u | 1u << 1u;
+  loco.bidi.error_counter = 1u;
   auto doc{loco.toJsonDocument()};
   std::string json;
   json.reserve(1024uz);
   serializeJson(doc, json);
-  EXPECT_EQ(json,
-            "{\"name\":\"Reihe "
-            "2190\",\"mode\":0,\"speed_steps\":4,\"rvvvvvvv\":170,\"f31_0\":10,"
-            "\"bidi\":{\"receive_counter\":0,\"error_counter\":0,\"options\":0,"
-            "\"speed\":0,\"qos\":0}}");
+  EXPECT_EQ(
+    json,
+    R"({"name":"Reihe 2190","mode":0,"speed_steps":4,"rvvvvvvv":170,"f31_0":10,"bidi":{"receive_counter":0,"error_counter":1,"options":0,"speed":0,"qos":0}})");
 }
 
 TEST_F(DccTest, json_to_loco) {
   std::string json{
-    "{\"name\":\"Reihe "
-    "2190\",\"mode\":0,\"speed_steps\":4,\"rvvvvvvv\":170,\"f31_0\":10}"};
+    R"({"name":"Reihe 2190","mode":0,"speed_steps":4,"rvvvvvvv":170,"f31_0":10,"bidi":{"receive_counter":0,"error_counter":1,"options":0,"speed":0,"qos":0}})"};
   JsonDocument doc;
   deserializeJson(doc, json);
-  mw::dcc::Loco loco;
-  loco.fromJsonDocument(doc);
+  mw::dcc::Loco loco{doc};
   EXPECT_EQ(loco.name, "Reihe 2190");
   EXPECT_EQ(loco.speed_steps, z21::LocoInfo::DCC128);
   EXPECT_EQ(loco.rvvvvvvv, 170u);
   EXPECT_EQ(loco.f31_0, 10u);
+  EXPECT_EQ(loco.bidi.error_counter, 1u);
 }

--- a/tests/mw/dcc/turnout.cpp
+++ b/tests/mw/dcc/turnout.cpp
@@ -1,0 +1,41 @@
+#include "dcc_test.hpp"
+#include "mw/dcc/loco.hpp"
+
+TEST_F(DccTest, turnout_to_json) {
+  mw::dcc::Turnout turnout;
+  turnout.name = "North";
+  turnout.position = z21::TurnoutInfo::Position::P1;
+  turnout.group = {
+    .addresses = {13u},
+    .states = {{z21::TurnoutInfo::Position::P0, z21::TurnoutInfo::Position::P0},
+               {z21::TurnoutInfo::Position::P0, z21::TurnoutInfo::Position::P1},
+               {z21::TurnoutInfo::Position::P1, z21::TurnoutInfo::Position::P0},
+               {z21::TurnoutInfo::Position::P1,
+                z21::TurnoutInfo::Position::P1}},
+  };
+  auto doc{turnout.toJsonDocument()};
+  std::string json;
+  json.reserve(1024uz);
+  serializeJson(doc, json);
+  std::cout << json << "\n";
+  EXPECT_EQ(
+    json,
+    R"({"name":"North","mode":0,"position":2,"type":0,"group":{"addresses":[13],"states":[[1,1],[1,2],[2,1],[2,2]]}})");
+}
+
+TEST_F(DccTest, json_to_turnout) {
+  std::string json{
+    R"({"name":"North","mode":0,"position":2,"type":0,"group":{"addresses":[13],"states":[[1,1],[1,2],[2,1],[2,2]]}})"};
+  JsonDocument doc;
+  deserializeJson(doc, json);
+  mw::dcc::Turnout turnout{doc};
+  EXPECT_EQ(turnout.name, "North");
+  EXPECT_EQ(turnout.group.addresses, decltype(turnout.group.addresses){13u});
+  EXPECT_EQ(
+    turnout.group.states,
+    (decltype(turnout.group.states){
+      {z21::TurnoutInfo::Position::P0, z21::TurnoutInfo::Position::P0},
+      {z21::TurnoutInfo::Position::P0, z21::TurnoutInfo::Position::P1},
+      {z21::TurnoutInfo::Position::P1, z21::TurnoutInfo::Position::P0},
+      {z21::TurnoutInfo::Position::P1, z21::TurnoutInfo::Position::P1}}));
+}

--- a/tools/scripts/dcc_turnouts_api.py
+++ b/tools/scripts/dcc_turnouts_api.py
@@ -1,0 +1,25 @@
+import json, requests
+
+run_get_requests = True
+run_put_requests = False
+run_delete_requests = False
+
+valid = '{"address":100,"name":"T72"}'
+invalid = '{"address":: '
+
+# Open session
+s = requests.Session()
+
+"""
+GET
+"""
+if run_get_requests:
+    r = s.get("http://remise.local/dcc/turnouts/")
+    print(str(r.request) + " " + str(r.url) + " " + str(r.status_code))
+    if len(r.content) and r.headers.get("content-type") == "application/json":
+        print(r.json())
+
+    r = s.get("http://remise.local/dcc/turnouts/3")
+    print(str(r.request) + " " + str(r.url) + " " + str(r.status_code))
+    if len(r.content) and r.headers.get("content-type") == "application/json":
+        print(r.json())


### PR DESCRIPTION
I've started adding turnouts, but there are still a couple of things missing
- `to`- and `fromJsonDocument` methods of `NvTurnoutBase` and `Turnout` :ballot_box_with_check:
  Question here is also if position should be stored in NVS or not? The original Z21 does not store that info.
- `turnoutsPutRequest` :ballot_box_with_check:
- Automatic timeout (if enabled in the settings), should probably switch of the output after 500ms
- Z21 lib accessory flags are missing

And then there is still the question of which addressing method should we use?
See: https://wiki.rocrail.net/doku.php?id=addressing:accessory-pg-de

The Z21 protocol and app seem to use some **flat addressing** (FADA), although the app is off by +1 for whatever reason.
E.g., setting address 5 in an MX820 will result in address 20 being sent in the protocol and address 21 being displayed in the app... :face_with_diagonal_mouth: 

And then there is the question of how to display decoders in the frontend?
How are we going to distinguish between a decoder using module based and one using flat addressing?
Problem is some decoders (e.g. the MX820) don't even support anything else but module based.
Should we just ignore that and use flat addressing anyhow?