### PR TITLE
Ethernet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##
+- Add Ethernet support through [W5500](https://wiznet.io/products/ethernet-chips/w5500) ([#123](https://github.com/OpenRemise/Firmware/issues/123))
+
 ## 0.6.1
 - Add [Z21 ᴡʟᴀɴMAUS](https://www.z21.eu/en/products/z21-wlanmaus) support ([#115](https://github.com/OpenRemise/Firmware/issues/115))
 - Bugfix restore DCC operations- after service mode provided it was previously enabled ([#113](https://github.com/OpenRemise/Firmware/issues/113))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ else()
     drv/analog/convert.cpp
     drv/analog/init.cpp
     drv/analog/temp_task_function.cpp
+    drv/eth/init.cpp
     drv/led/bug.cpp
     drv/led/init.cpp
     drv/led/wifi.cpp
@@ -97,6 +98,7 @@ else()
     driver
     esp_adc
     esp_app_format
+    esp_eth
     esp_http_server
     esp_wifi
     nvs_flash

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -278,6 +278,27 @@ inline struct TemperatureQueue {
 
 } // namespace analog
 
+namespace eth {
+
+/// W5500 SPI chip select
+inline constexpr auto cs_gpio_num{GPIO_NUM_42};
+
+/// W5500 SPI clock
+inline constexpr auto sclk_gpio_num{GPIO_NUM_2};
+
+/// W5500 SPI MISO
+inline constexpr auto miso_gpio_num{GPIO_NUM_40};
+
+/// W5500 SPI MOSI
+inline constexpr auto mosi_gpio_num{GPIO_NUM_41};
+
+inline std::array<char, 16uz> ip{};
+inline std::string ip_str{};
+inline std::array<uint8_t, 6uz> mac{};
+inline std::string mac_str(2uz * 6uz + 5uz + sizeof('\n'), '\0');
+
+} // namespace eth
+
 namespace led {
 
 /// Bug LED pin used to indicate errors or updates
@@ -418,12 +439,12 @@ inline SHARED_TASK(task,
 
 namespace wifi {
 
+//
+using eth::ip, eth::ip_str, eth::mac, eth::mac_str;
+
 #if CONFIG_IDF_TARGET_ESP32S3
 inline std::vector<wifi_ap_record_t> ap_records;
 #endif
-inline std::string ip_str;
-inline std::array<uint8_t, 6uz> mac;
-inline std::string mac_str(2uz * 6uz + 5uz + sizeof('\n'), '\0');
 
 ///
 inline TASK(task,

--- a/src/drv/analog/doxygen.hpp
+++ b/src/drv/analog/doxygen.hpp
@@ -52,7 +52,7 @@ namespace drv::analog {
 /// <div class="section_buttons">
 /// | Previous      | Next              |
 /// | :------------ | ----------------: |
-/// | \ref page_drv | \ref page_drv_led |
+/// | \ref page_drv | \ref page_drv_eth |
 /// </div>
 
 } // namespace drv::analog

--- a/src/drv/analog/init.cpp
+++ b/src/drv/analog/init.cpp
@@ -39,12 +39,13 @@ namespace {
 ///
 /// \retval ESP_OK  Success
 esp_err_t init_gpio() {
-  static constexpr gpio_config_t io_conf{.pin_bit_mask = 1ull << ol_on_gpio_num,
-                                         .mode = GPIO_MODE_OUTPUT,
-                                         .pull_up_en = GPIO_PULLUP_DISABLE,
-                                         .pull_down_en = GPIO_PULLDOWN_DISABLE,
-                                         .intr_type = GPIO_INTR_DISABLE};
-  ESP_ERROR_CHECK(gpio_config(&io_conf));
+  static constexpr gpio_config_t gpio_cfg{.pin_bit_mask = 1ull
+                                                          << ol_on_gpio_num,
+                                          .mode = GPIO_MODE_OUTPUT,
+                                          .pull_up_en = GPIO_PULLUP_DISABLE,
+                                          .pull_down_en = GPIO_PULLDOWN_DISABLE,
+                                          .intr_type = GPIO_INTR_DISABLE};
+  ESP_ERROR_CHECK(gpio_config(&gpio_cfg));
   return gpio_set_level(ol_on_gpio_num, 0u);
 }
 
@@ -73,17 +74,17 @@ esp_err_t init() {
   ESP_ERROR_CHECK(init_gpio());
 
   // Curve fitting calibration
-  static constexpr adc_cali_curve_fitting_config_t cali_config{
+  static constexpr adc_cali_curve_fitting_config_t cali_cfg{
     .unit_id = ADC_UNIT_1,
     .atten = attenuation,
     .bitwidth = static_cast<adc_bitwidth_t>(SOC_ADC_DIGI_MAX_BITWIDTH),
   };
   static_assert(SOC_ADC_DIGI_MAX_BITWIDTH == ADC_BITWIDTH_12);
   ESP_ERROR_CHECK(
-    adc_cali_create_scheme_curve_fitting(&cali_config, &cali_handle));
+    adc_cali_create_scheme_curve_fitting(&cali_cfg, &cali_handle));
 
   // Both of those values are sizes in bytes
-  static constexpr adc_continuous_handle_cfg_t adc_config{
+  static constexpr adc_continuous_handle_cfg_t adc_cfg{
     .max_store_buf_size = conversion_frame_size * 2u,
     .conv_frame_size = conversion_frame_size,
     .flags =
@@ -91,7 +92,7 @@ esp_err_t init() {
         .flush_pool = true,
       },
   };
-  ESP_ERROR_CHECK(adc_continuous_new_handle(&adc_config, &adc1_handle));
+  ESP_ERROR_CHECK(adc_continuous_new_handle(&adc_cfg, &adc1_handle));
 
   // Create same pattern for both channels
   auto pattern{std::invoke([] {
@@ -115,10 +116,9 @@ esp_err_t init() {
   ESP_ERROR_CHECK(adc_continuous_config(adc1_handle, &dig_cfg));
 
   // Initialize internal temperature sensor
-  static constexpr temperature_sensor_config_t temp_sensor_config =
+  static constexpr temperature_sensor_config_t temp_sensor_cfg =
     TEMPERATURE_SENSOR_CONFIG_DEFAULT(-10, 80);
-  ESP_ERROR_CHECK(
-    temperature_sensor_install(&temp_sensor_config, &temp_sensor));
+  ESP_ERROR_CHECK(temperature_sensor_install(&temp_sensor_cfg, &temp_sensor));
   ESP_ERROR_CHECK(temperature_sensor_enable(temp_sensor));
 
   // Create ADC and temp tasks

--- a/src/drv/doxygen.hpp
+++ b/src/drv/doxygen.hpp
@@ -33,6 +33,7 @@ namespace drv {
 /// | Chapter                  | Namespace   | Content                                      |
 /// | ------------------------ | ----------- | ---------------------------------------------|
 /// | \subpage page_drv_analog | \ref analog | ADC measurements, overcurrent                |
+/// | \subpage page_drv_eth    | \ref eth    | Setup Ethernet                               |
 /// | \subpage page_drv_led    | \ref led    | Dimming LEDs                                 |
 /// | \subpage page_drv_out    | \ref out    | Generation of various SUSI and track signals |
 /// | \subpage page_drv_trace  | \ref trace  | Debug purposes                               |

--- a/src/drv/eth/doxygen.hpp
+++ b/src/drv/eth/doxygen.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Vincent Hamp
+// Copyright (C) 2026 Vincent Hamp
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -13,27 +13,25 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-/// Trace (IO pins to toggle for debug purposes)
+/// Ethernet documentation
 ///
-/// \file   drv/trace/init.cpp
+/// \file   drv/eth/doxygen.hpp
 /// \author Vincent Hamp
-/// \date   09/02/2023
+/// \date   28/01/2026
 
-#include "init.hpp"
-#include <driver/gpio.h>
-#include <soc/uart_pins.h>
+#pragma once
 
-namespace drv::trace {
+namespace drv::eth {
 
-/// \todo document
-esp_err_t init() {
-  static constexpr gpio_config_t gpio_cfg{
-    .pin_bit_mask = 1ull << U0RXD_GPIO_NUM | 1ull << U0TXD_GPIO_NUM,
-    .mode = GPIO_MODE_OUTPUT,
-    .pull_up_en = GPIO_PULLUP_DISABLE,
-    .pull_down_en = GPIO_PULLDOWN_DISABLE,
-    .intr_type = GPIO_INTR_DISABLE};
-  return gpio_config(&gpio_cfg);
-}
+/// \page page_drv_eth Ethernet
+/// \details \tableofcontents
+/// \todo document Ethernet page
+/// W5500, connectivity extension only, ...
+///
+/// <div class="section_buttons">
+/// | Previous             | Next              |
+/// | :------------------- | ----------------: |
+/// | \ref page_drv_analog | \ref page_drv_led |
+/// </div>
 
-} // namespace drv::trace
+} // namespace drv::eth

--- a/src/drv/eth/init.cpp
+++ b/src/drv/eth/init.cpp
@@ -1,0 +1,188 @@
+// Copyright (C) 2026 Vincent Hamp
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/// Initialize Ethernet
+///
+/// \file   drv/eth/init.cpp
+/// \author Vincent Hamp
+/// \date   28/01/2026
+
+#pragma once
+
+#include <driver/gpio.h>
+#include <esp_eth_driver.h>
+#include <esp_eth_netif_glue.h>
+#include <esp_mac.h>
+#include <esp_netif.h>
+#include <cassert>
+#include "drv/led/wifi.hpp"
+#include "log.h"
+#include "mem/nvs/settings.hpp"
+
+namespace drv::eth {
+
+namespace {
+
+eth_link_t volatile link_status{ETH_LINK_DOWN};
+
+/// \todo document
+void event_handler(void*,
+                   esp_event_base_t event_base,
+                   int32_t event_id,
+                   void* event_data) {
+  // Ethernet got IP from connected AP
+  if (event_base == IP_EVENT && event_id == IP_EVENT_ETH_GOT_IP) {
+    auto const event{std::bit_cast<ip_event_got_ip_t*>(event_data)};
+    auto const count{
+      snprintf(data(ip), size(ip), IPSTR, IP2STR(&event->ip_info.ip))};
+    ip_str.replace(0uz, count, data(ip));
+    led::wifi(true);
+    LOGI("IP_EVENT_ETH_GOT_IP %s", ip_str.c_str());
+  }
+  // Ethernet lost IP and the IP is reset to
+  else if (event_base == IP_EVENT && event_id == IP_EVENT_ETH_LOST_IP) {
+    ip.fill(0);
+    ip_str.clear();
+    led::wifi(false);
+    LOGI("IP_EVENT_ETH_LOST_IP");
+  }
+  // Ethernet got a valid link
+  else if (event_base == ETH_EVENT && event_id == ETHERNET_EVENT_CONNECTED) {
+    link_status = ETH_LINK_UP;
+    LOGI("ETHERNET_EVENT_CONNECTED");
+  }
+  // Ethernet lost a valid link
+  else if (event_base == ETH_EVENT && event_id == ETHERNET_EVENT_DISCONNECTED) {
+    link_status = ETH_LINK_DOWN;
+    ip.fill(0);
+    ip_str.clear();
+    led::wifi(false);
+    LOGI("ETHERNET_EVENT_DISCONNECTED");
+  }
+}
+
+} // namespace
+
+/// \todo document
+esp_err_t init() {
+  // Set global MAC string
+  ESP_ERROR_CHECK(esp_base_mac_addr_get(data(mac)));
+  snprintf(data(mac_str), size(mac_str), MACSTR, MAC2STR(mac));
+
+  // Initialize TCP/IP stack and event loop
+  esp_netif_init();
+  esp_event_loop_create_default();
+
+  static constexpr spi_bus_config_t buf_cfg{.mosi_io_num = mosi_gpio_num,
+                                            .miso_io_num = miso_gpio_num,
+                                            .sclk_io_num = sclk_gpio_num,
+                                            .data2_io_num = -1,
+                                            .data3_io_num = -1,
+                                            .data4_io_num = -1,
+                                            .data5_io_num = -1,
+                                            .data6_io_num = -1,
+                                            .data7_io_num = -1};
+
+  spi_bus_initialize(SPI3_HOST, &buf_cfg, SPI_DMA_CH_AUTO);
+
+  spi_device_interface_config_t dev_cfg{.mode = 0,
+                                        .clock_speed_hz =
+                                          static_cast<int>(30e6),
+                                        .spics_io_num = cs_gpio_num,
+                                        .queue_size = 20};
+
+  eth_w5500_config_t w5500_cfg{.int_gpio_num = -1,
+                               .poll_period_ms = 10u,
+                               .spi_host_id = SPI3_HOST,
+                               .spi_devcfg = &dev_cfg};
+
+  // Init common MAC and PHY configs to default
+  static constexpr eth_mac_config_t mac_cfg{.sw_reset_timeout_ms = 100u,
+                                            .rx_task_stack_size = 4096u,
+                                            .rx_task_prio = 15u,
+                                            .flags = 0u};
+  static constexpr eth_phy_config_t phy_cfg{.phy_addr = ESP_ETH_PHY_ADDR_AUTO,
+                                            .reset_timeout_ms = 100u,
+                                            .autonego_timeout_ms = 4000u,
+                                            .reset_gpio_num = -1,
+                                            .hw_reset_assert_time_us = 0,
+                                            .post_hw_reset_delay_ms = 0};
+
+  esp_eth_mac_t* eth_mac{esp_eth_mac_new_w5500(&w5500_cfg, &mac_cfg)};
+  esp_eth_phy_t* eth_phy{esp_eth_phy_new_w5500(&phy_cfg)};
+
+  // Init Ethernet driver to default and install it
+  esp_eth_handle_t eth_handle{NULL};
+  esp_eth_config_t eth_cfg_spi = ETH_DEFAULT_CONFIG(eth_mac, eth_phy);
+  if (auto const err{esp_eth_driver_install(&eth_cfg_spi, &eth_handle)}) {
+    LOGE("esp_eth_driver_install failed %s", esp_err_to_name(err));
+    ESP_ERROR_CHECK(eth_phy->del(eth_phy));
+    ESP_ERROR_CHECK(eth_mac->del(eth_mac));
+    ESP_ERROR_CHECK(spi_bus_free(SPI3_HOST));
+    return ESP_ERR_NOT_FOUND;
+  }
+
+  // W5500 has no internal unique MAC
+  ESP_ERROR_CHECK(esp_base_mac_addr_get(data(mac)));
+  ESP_ERROR_CHECK(esp_eth_ioctl(eth_handle, ETH_CMD_S_MAC_ADDR, data(mac)));
+
+  // Create the network interface handle
+  esp_netif_config_t netif_cfg = ESP_NETIF_DEFAULT_ETH();
+  esp_netif_t* netif{esp_netif_new(&netif_cfg)};
+  assert(netif);
+
+  // Attach
+  esp_eth_netif_glue_handle_t eth_glue{esp_eth_new_netif_glue(eth_handle)};
+  ESP_ERROR_CHECK(esp_netif_attach(netif, eth_glue));
+  ESP_ERROR_CHECK(esp_netif_set_default_netif(netif));
+
+  // Register event handlers
+  ESP_ERROR_CHECK(esp_event_handler_register(
+    IP_EVENT, IP_EVENT_ETH_GOT_IP, &event_handler, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_register(
+    IP_EVENT, IP_EVENT_ETH_LOST_IP, &event_handler, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_register(
+    ETH_EVENT, ETHERNET_EVENT_CONNECTED, &event_handler, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_register(
+    ETH_EVENT, ETHERNET_EVENT_DISCONNECTED, &event_handler, NULL));
+
+  // Static IP
+  mem::nvs::Settings nvs;
+  auto const sta_ip{nvs.getStationIP()};
+  auto const sta_netmask{nvs.getStationNetmask()};
+  auto const sta_gateway{nvs.getStationGateway()};
+  if (!empty(sta_ip) && !empty(sta_netmask) && !empty(sta_gateway)) {
+    esp_netif_ip_info_t ip_info;
+    ESP_ERROR_CHECK(esp_netif_str_to_ip4(sta_ip.c_str(), &ip_info.ip));
+    ESP_ERROR_CHECK(
+      esp_netif_str_to_ip4(sta_netmask.c_str(), &ip_info.netmask));
+    ESP_ERROR_CHECK(esp_netif_str_to_ip4(sta_gateway.c_str(), &ip_info.gw));
+    auto netif{esp_netif_get_default_netif()};
+    ESP_ERROR_CHECK(esp_netif_dhcpc_stop(netif));
+    ESP_ERROR_CHECK(esp_netif_set_ip_info(netif, &ip_info));
+  }
+
+  ESP_ERROR_CHECK(esp_eth_start(eth_handle));
+
+  // Wait for ETHERNET_EVENT_CONNECTED
+  for (auto const then{xTaskGetTickCount() + pdMS_TO_TICKS(5'000u)};
+       xTaskGetTickCount() < then;)
+    if (link_status == ETH_LINK_UP) return ESP_OK;
+    else vTaskDelay(pdMS_TO_TICKS(100u));
+
+  return ESP_ERR_TIMEOUT;
+}
+
+} // namespace drv::eth

--- a/src/drv/eth/init.hpp
+++ b/src/drv/eth/init.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Vincent Hamp
+// Copyright (C) 2026 Vincent Hamp
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -13,27 +13,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-/// Trace (IO pins to toggle for debug purposes)
+/// Initialize Ethernet
 ///
-/// \file   drv/trace/init.cpp
+/// \file   drv/eth/init.hpp
 /// \author Vincent Hamp
-/// \date   09/02/2023
+/// \date   28/01/2026
 
-#include "init.hpp"
-#include <driver/gpio.h>
-#include <soc/uart_pins.h>
+#pragma once
 
-namespace drv::trace {
+#include <esp_err.h>
 
-/// \todo document
-esp_err_t init() {
-  static constexpr gpio_config_t gpio_cfg{
-    .pin_bit_mask = 1ull << U0RXD_GPIO_NUM | 1ull << U0TXD_GPIO_NUM,
-    .mode = GPIO_MODE_OUTPUT,
-    .pull_up_en = GPIO_PULLUP_DISABLE,
-    .pull_down_en = GPIO_PULLDOWN_DISABLE,
-    .intr_type = GPIO_INTR_DISABLE};
-  return gpio_config(&gpio_cfg);
-}
+namespace drv::eth {
 
-} // namespace drv::trace
+esp_err_t init();
+
+} // namespace drv::eth

--- a/src/drv/led/doxygen.hpp
+++ b/src/drv/led/doxygen.hpp
@@ -49,9 +49,9 @@ namespace drv::led {
 /// mem::nvs::Settings::getLedDutyCycleWiFi().
 ///
 /// <div class="section_buttons">
-/// | Previous             | Next              |
-/// | :------------------- | ----------------: |
-/// | \ref page_drv_analog | \ref page_drv_out |
+/// | Previous          | Next              |
+/// | :---------------- | ----------------: |
+/// | \ref page_drv_eth | \ref page_drv_out |
 /// </div>
 
 } // namespace drv::led

--- a/src/drv/led/init.cpp
+++ b/src/drv/led/init.cpp
@@ -31,38 +31,38 @@ namespace drv::led {
 /// timer with 2 channels for the bug and WiFi LEDs. The resolution of the PWM
 /// is 8 bits.
 esp_err_t init() {
-  static constexpr ledc_timer_config_t timer{.speed_mode = LEDC_LOW_SPEED_MODE,
-                                             .duty_resolution =
-                                               LEDC_TIMER_8_BIT,
-                                             .timer_num = LEDC_TIMER_0,
-                                             .freq_hz = 4000,
-                                             .clk_cfg = LEDC_AUTO_CLK};
-  ESP_ERROR_CHECK(ledc_timer_config(&timer));
+  static constexpr ledc_timer_config_t timer_cfg{
+    .speed_mode = LEDC_LOW_SPEED_MODE,
+    .duty_resolution = LEDC_TIMER_8_BIT,
+    .timer_num = LEDC_TIMER_0,
+    .freq_hz = 4000,
+    .clk_cfg = LEDC_AUTO_CLK};
+  ESP_ERROR_CHECK(ledc_timer_config(&timer_cfg));
 
   {
-    static constexpr ledc_channel_config_t cfg{.gpio_num = bug_gpio_num,
-                                               .speed_mode =
-                                                 LEDC_LOW_SPEED_MODE,
-                                               .channel = bug_channel,
-                                               .intr_type = LEDC_INTR_DISABLE,
-                                               .timer_sel = LEDC_TIMER_0,
-                                               .duty = 0u,
-                                               .hpoint = 0};
-    ESP_ERROR_CHECK(ledc_channel_config(&cfg));
+    static constexpr ledc_channel_config_t channel_cfg{
+      .gpio_num = bug_gpio_num,
+      .speed_mode = LEDC_LOW_SPEED_MODE,
+      .channel = bug_channel,
+      .intr_type = LEDC_INTR_DISABLE,
+      .timer_sel = LEDC_TIMER_0,
+      .duty = 0u,
+      .hpoint = 0};
+    ESP_ERROR_CHECK(ledc_channel_config(&channel_cfg));
     ESP_ERROR_CHECK(ledc_set_duty(LEDC_LOW_SPEED_MODE, bug_channel, 0u));
     ESP_ERROR_CHECK(ledc_update_duty(LEDC_LOW_SPEED_MODE, bug_channel));
   }
 
   {
-    static constexpr ledc_channel_config_t cfg{.gpio_num = wifi_gpio_num,
-                                               .speed_mode =
-                                                 LEDC_LOW_SPEED_MODE,
-                                               .channel = wifi_channel,
-                                               .intr_type = LEDC_INTR_DISABLE,
-                                               .timer_sel = LEDC_TIMER_0,
-                                               .duty = 0u,
-                                               .hpoint = 0};
-    ESP_ERROR_CHECK(ledc_channel_config(&cfg));
+    static constexpr ledc_channel_config_t channel_cfg{
+      .gpio_num = wifi_gpio_num,
+      .speed_mode = LEDC_LOW_SPEED_MODE,
+      .channel = wifi_channel,
+      .intr_type = LEDC_INTR_DISABLE,
+      .timer_sel = LEDC_TIMER_0,
+      .duty = 0u,
+      .hpoint = 0};
+    ESP_ERROR_CHECK(ledc_channel_config(&channel_cfg));
     ESP_ERROR_CHECK(ledc_set_duty(LEDC_LOW_SPEED_MODE, wifi_channel, 0u));
     return ledc_update_duty(LEDC_LOW_SPEED_MODE, wifi_channel);
   }

--- a/src/drv/out/init.cpp
+++ b/src/drv/out/init.cpp
@@ -27,13 +27,13 @@ namespace drv::out {
 
 /// \todo document
 esp_err_t init_gptimer() {
-  static constexpr gptimer_config_t timer_config{
+  static constexpr gptimer_config_t timer_cfg{
     .clk_src = GPTIMER_CLK_SRC_DEFAULT,
     .direction = GPTIMER_COUNT_UP,
     .resolution_hz = 1'000'000u, // 1 MHz
     .intr_priority = 2           // Priority 3 is taken by RMT!
   };
-  ESP_ERROR_CHECK(gptimer_new_timer(&timer_config, &gptimer));
+  ESP_ERROR_CHECK(gptimer_new_timer(&timer_cfg, &gptimer));
 
   // Install interrupt (nullptr argument doesn't matter)
   gptimer_event_callbacks_t cbs{.on_alarm = nullptr};

--- a/src/drv/out/susi/init.cpp
+++ b/src/drv/out/susi/init.cpp
@@ -21,6 +21,7 @@
 
 #include "init.hpp"
 #include <driver/gpio.h>
+#include <driver/spi_master.h>
 #include "log.h"
 #include "zimo/zusi/task_function.hpp"
 
@@ -28,32 +29,32 @@ namespace drv::out::susi {
 
 /// \todo document
 esp_err_t init() {
-  static constexpr gpio_config_t io_conf{.pin_bit_mask = 1ull
-                                                         << enable_gpio_num,
-                                         .mode = GPIO_MODE_OUTPUT,
-                                         .pull_up_en = GPIO_PULLUP_DISABLE,
-                                         .pull_down_en = GPIO_PULLDOWN_DISABLE,
-                                         .intr_type = GPIO_INTR_DISABLE};
-  ESP_ERROR_CHECK(gpio_config(&io_conf));
+  static constexpr gpio_config_t gpio_cfg{.pin_bit_mask = 1ull
+                                                          << enable_gpio_num,
+                                          .mode = GPIO_MODE_OUTPUT,
+                                          .pull_up_en = GPIO_PULLUP_DISABLE,
+                                          .pull_down_en = GPIO_PULLDOWN_DISABLE,
+                                          .intr_type = GPIO_INTR_DISABLE};
+  ESP_ERROR_CHECK(gpio_config(&gpio_cfg));
 
-  static constexpr spi_bus_config_t buscfg{.mosi_io_num = data_gpio_num,
-                                           .miso_io_num = -1,
-                                           .sclk_io_num = clock_gpio_num,
-                                           .data2_io_num = -1,
-                                           .data3_io_num = -1,
-                                           .data4_io_num = -1,
-                                           .data5_io_num = -1,
-                                           .data6_io_num = -1,
-                                           .data7_io_num = -1};
+  static constexpr spi_bus_config_t bus_cfg{.mosi_io_num = data_gpio_num,
+                                            .miso_io_num = -1,
+                                            .sclk_io_num = clock_gpio_num,
+                                            .data2_io_num = -1,
+                                            .data3_io_num = -1,
+                                            .data4_io_num = -1,
+                                            .data5_io_num = -1,
+                                            .data6_io_num = -1,
+                                            .data7_io_num = -1};
 
-  // Can't use SPI0 or 1
-  spi_bus_initialize(SPI2_HOST, &buscfg, SPI_DMA_CH_AUTO);
+  // Can't use SPI1
+  ESP_ERROR_CHECK(spi_bus_initialize(SPI2_HOST, &bus_cfg, SPI_DMA_CH_AUTO));
 
-  spi_device_interface_config_t devcfg{
+  spi_device_interface_config_t dev_cfg{
     .command_bits = 0u,
     .address_bits = 0u,
     .dummy_bits = 0u,
-    .mode = 1u, // Fuck the docs, mode ain't 3...
+    .mode = 1u,
     .duty_cycle_pos = 0u,
     .cs_ena_pretrans = 0u,
     .cs_ena_posttrans = 0u,
@@ -62,16 +63,17 @@ esp_err_t init() {
     .spics_io_num = -1,
     .flags = SPI_DEVICE_BIT_LSBFIRST | SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_3WIRE,
     .queue_size = 7};
-  spi_bus_add_device(SPI2_HOST, &devcfg, &spis[0uz]); // Fallback and resync
+  ESP_ERROR_CHECK(
+    spi_bus_add_device(SPI2_HOST, &dev_cfg, &spis[0uz])); // Fallback and resync
 
-  devcfg.clock_speed_hz = static_cast<int>(1.0 / 3.5e-6);
-  spi_bus_add_device(SPI2_HOST, &devcfg, &spis[1uz]);
+  dev_cfg.clock_speed_hz = static_cast<int>(1.0 / 3.5e-6);
+  ESP_ERROR_CHECK(spi_bus_add_device(SPI2_HOST, &dev_cfg, &spis[1uz]));
 
-  devcfg.clock_speed_hz = static_cast<int>(1.0 / 0.733e-6);
-  spi_bus_add_device(SPI2_HOST, &devcfg, &spis[2uz]);
+  dev_cfg.clock_speed_hz = static_cast<int>(1.0 / 0.733e-6);
+  ESP_ERROR_CHECK(spi_bus_add_device(SPI2_HOST, &dev_cfg, &spis[2uz]));
 
-  devcfg.clock_speed_hz = static_cast<int>(1.0 / 0.5533e-6);
-  spi_bus_add_device(SPI2_HOST, &devcfg, &spis[3uz]);
+  dev_cfg.clock_speed_hz = static_cast<int>(1.0 / 0.5533e-6);
+  ESP_ERROR_CHECK(spi_bus_add_device(SPI2_HOST, &dev_cfg, &spis[3uz]));
 
   zimo::zusi::task.function = zimo::zusi::task_function;
 

--- a/src/drv/out/track/dcc/resume.cpp
+++ b/src/drv/out/track/dcc/resume.cpp
@@ -27,9 +27,9 @@
 namespace drv::out::track::dcc {
 
 /// \todo document
-esp_err_t init_encoder(dcc_encoder_config_t const& encoder_config) {
+esp_err_t init_encoder(dcc_encoder_config_t const& encoder_cfg) {
   assert(!encoder);
-  return rmt_new_dcc_encoder(&encoder_config, &encoder);
+  return rmt_new_dcc_encoder(&encoder_cfg, &encoder);
 }
 
 /// \todo document
@@ -49,7 +49,7 @@ esp_err_t init_alarm(gptimer_alarm_cb_t gptimer_cb) {
 /// \todo document
 esp_err_t init_bidi() {
   //
-  static constexpr uart_config_t uart_config{
+  static constexpr uart_config_t uart_cfg{
     .baud_rate = ::dcc::bidi::baudrate,
     .data_bits = UART_DATA_8_BITS,
     .parity = UART_PARITY_DISABLE,
@@ -59,7 +59,7 @@ esp_err_t init_bidi() {
   };
   ESP_ERROR_CHECK(uart_driver_install(
     UART_NUM_1, SOC_UART_FIFO_LEN * 2, 0, 0, NULL, ESP_INTR_FLAG_IRAM));
-  ESP_ERROR_CHECK(uart_param_config(UART_NUM_1, &uart_config));
+  ESP_ERROR_CHECK(uart_param_config(UART_NUM_1, &uart_cfg));
   return uart_set_pin(UART_NUM_1,
                       UART_PIN_NO_CHANGE,
                       bidi_rx_gpio_num,
@@ -75,10 +75,10 @@ esp_err_t init_gpio() {
 }
 
 /// \todo document
-esp_err_t resume(dcc_encoder_config_t const& encoder_config,
+esp_err_t resume(dcc_encoder_config_t const& encoder_cfg,
                  rmt_tx_done_callback_t rmt_cb,
                  gptimer_alarm_cb_t gptimer_cb) {
-  ESP_ERROR_CHECK(init_encoder(encoder_config));
+  ESP_ERROR_CHECK(init_encoder(encoder_cfg));
   ESP_ERROR_CHECK(init_rmt(rmt_cb));
   ESP_ERROR_CHECK(init_alarm(gptimer_cb));
   ESP_ERROR_CHECK(init_bidi());

--- a/src/drv/out/track/dcc/resume.hpp
+++ b/src/drv/out/track/dcc/resume.hpp
@@ -26,12 +26,12 @@
 
 namespace drv::out::track::dcc {
 
-esp_err_t init_encoder(dcc_encoder_config_t const& encoder_config);
+esp_err_t init_encoder(dcc_encoder_config_t const& encoder_cfg);
 esp_err_t init_rmt(rmt_tx_done_callback_t rmt_cb);
 esp_err_t init_alarm(gptimer_alarm_cb_t gptimer_cb);
 esp_err_t init_bidi();
 esp_err_t init_gpio();
-esp_err_t resume(dcc_encoder_config_t const& encoder_config,
+esp_err_t resume(dcc_encoder_config_t const& encoder_cfg,
                  rmt_tx_done_callback_t rmt_cb,
                  gptimer_alarm_cb_t gptimer_cb);
 

--- a/src/drv/out/track/init.cpp
+++ b/src/drv/out/track/init.cpp
@@ -44,7 +44,7 @@ void IRAM_ATTR nfault_isr_handler(void*) {
 
 /// \todo document RMT pin no longer tristate after that
 esp_err_t init_channel() {
-  static constexpr rmt_tx_channel_config_t chan_config{
+  static constexpr rmt_tx_channel_config_t channel_cfg{
     .gpio_num = p_gpio_num,
     .clk_src = RMT_CLK_SRC_DEFAULT,
     .resolution_hz = 1'000'000u,
@@ -59,7 +59,7 @@ esp_err_t init_channel() {
       .io_loop_back = false,
       .io_od_mode = false,
     }};
-  ESP_ERROR_CHECK(rmt_new_tx_channel(&chan_config, &channel));
+  ESP_ERROR_CHECK(rmt_new_tx_channel(&channel_cfg, &channel));
   return rmt_enable(channel);
 }
 
@@ -67,27 +67,27 @@ esp_err_t init_channel() {
 esp_err_t init_gpio() {
   // Inputs and outputs
   {
-    static constexpr gpio_config_t io_conf{
+    static constexpr gpio_config_t gpio_cfg{
       .pin_bit_mask = 1ull << ilim0_gpio_num | 1ull << ilim1_gpio_num |
                       1ull << enable_gpio_num,
       .mode = GPIO_MODE_INPUT_OUTPUT,
       .pull_up_en = GPIO_PULLUP_DISABLE,
       .pull_down_en = GPIO_PULLDOWN_DISABLE,
       .intr_type = GPIO_INTR_DISABLE};
-    ESP_ERROR_CHECK(gpio_config(&io_conf));
+    ESP_ERROR_CHECK(gpio_config(&gpio_cfg));
     ESP_ERROR_CHECK(gpio_set_level(enable_gpio_num, 0u));
   }
 
   // Outputs
   {
-    static constexpr gpio_config_t io_conf{
+    static constexpr gpio_config_t gpio_cfg{
       .pin_bit_mask = 1ull << nsleep_gpio_num | 1ull << n_force_low_gpio_num |
                       1ull << dcc::bidi_en_gpio_num,
       .mode = GPIO_MODE_OUTPUT,
       .pull_up_en = GPIO_PULLUP_DISABLE,
       .pull_down_en = GPIO_PULLDOWN_DISABLE,
       .intr_type = GPIO_INTR_DISABLE};
-    ESP_ERROR_CHECK(gpio_config(&io_conf));
+    ESP_ERROR_CHECK(gpio_config(&gpio_cfg));
     ESP_ERROR_CHECK(gpio_set_level(n_force_low_gpio_num, 1u));
     ESP_ERROR_CHECK(gpio_set_level(dcc::bidi_en_gpio_num, 0u));
     ESP_ERROR_CHECK(gpio_set_level(nsleep_gpio_num, 1u));
@@ -103,29 +103,29 @@ esp_err_t init_gpio() {
 
   //
   {
-    static constexpr gpio_config_t io_conf{
+    static constexpr gpio_config_t gpio_cfg{
       .pin_bit_mask = 1ull << nfault_gpio_num,
       .mode = GPIO_MODE_INPUT,
       .pull_up_en = GPIO_PULLUP_ENABLE,
       .pull_down_en = GPIO_PULLDOWN_DISABLE,
       .intr_type = GPIO_INTR_NEGEDGE};
-    ESP_ERROR_CHECK(gpio_config(&io_conf));
+    ESP_ERROR_CHECK(gpio_config(&gpio_cfg));
   }
 
   //
   {
-    static constexpr gpio_config_t io_conf{.pin_bit_mask = 1ull << ack_gpio_num,
-                                           .mode = GPIO_MODE_INPUT,
-                                           .pull_up_en = GPIO_PULLUP_ENABLE,
-                                           .pull_down_en =
-                                             GPIO_PULLDOWN_DISABLE,
-                                           .intr_type = GPIO_INTR_NEGEDGE};
-    ESP_ERROR_CHECK(gpio_config(&io_conf));
+    static constexpr gpio_config_t gpio_cfg{
+      .pin_bit_mask = 1ull << ack_gpio_num,
+      .mode = GPIO_MODE_INPUT,
+      .pull_up_en = GPIO_PULLUP_ENABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_NEGEDGE};
+    ESP_ERROR_CHECK(gpio_config(&gpio_cfg));
 
     gpio_glitch_filter_handle_t filter;
-    static constexpr gpio_pin_glitch_filter_config_t config{
+    static constexpr gpio_pin_glitch_filter_config_t filter_cfg{
       .clk_src = GLITCH_FILTER_CLK_SRC_DEFAULT, .gpio_num = ack_gpio_num};
-    ESP_ERROR_CHECK(gpio_new_pin_glitch_filter(&config, &filter));
+    ESP_ERROR_CHECK(gpio_new_pin_glitch_filter(&filter_cfg, &filter));
     ESP_ERROR_CHECK(gpio_glitch_filter_enable(filter));
   }
 

--- a/src/drv/out/track/zimo/decup/resume.cpp
+++ b/src/drv/out/track/zimo/decup/resume.cpp
@@ -25,9 +25,9 @@
 namespace drv::out::track::zimo::decup {
 
 /// \todo document
-esp_err_t init_encoder(decup_encoder_config_t const& encoder_config) {
+esp_err_t init_encoder(decup_encoder_config_t const& encoder_cfg) {
   assert(!encoder);
-  return rmt_new_decup_encoder(&encoder_config, &encoder);
+  return rmt_new_decup_encoder(&encoder_cfg, &encoder);
 }
 
 namespace {
@@ -47,10 +47,10 @@ esp_err_t init_gpio(gpio_isr_t gpio_isr_handler) {
 } // namespace
 
 /// \todo document
-esp_err_t resume(decup_encoder_config_t const& encoder_config,
+esp_err_t resume(decup_encoder_config_t const& encoder_cfg,
                  rmt_tx_done_callback_t rmt_cb,
                  gpio_isr_t gpio_isr_handler) {
-  ESP_ERROR_CHECK(init_encoder(encoder_config));
+  ESP_ERROR_CHECK(init_encoder(encoder_cfg));
   ESP_ERROR_CHECK(init_rmt(rmt_cb));
   return init_gpio(gpio_isr_handler);
 }

--- a/src/drv/out/track/zimo/decup/resume.hpp
+++ b/src/drv/out/track/zimo/decup/resume.hpp
@@ -27,8 +27,8 @@
 
 namespace drv::out::track::zimo::decup {
 
-esp_err_t init_encoder(decup_encoder_config_t const& encoder_config);
-esp_err_t resume(decup_encoder_config_t const& encoder_config,
+esp_err_t init_encoder(decup_encoder_config_t const& encoder_cfg);
+esp_err_t resume(decup_encoder_config_t const& encoder_cfg,
                  rmt_tx_done_callback_t rmt_cb,
                  gpio_isr_t gpio_isr_handler);
 

--- a/src/drv/out/track/zimo/mdu/resume.cpp
+++ b/src/drv/out/track/zimo/mdu/resume.cpp
@@ -25,9 +25,9 @@
 namespace drv::out::track::zimo::mdu {
 
 /// \todo document
-esp_err_t init_encoder(mdu_encoder_config_t const& encoder_config) {
+esp_err_t init_encoder(mdu_encoder_config_t const& encoder_cfg) {
   assert(!encoder);
-  return rmt_new_mdu_encoder(&encoder_config, &encoder);
+  return rmt_new_mdu_encoder(&encoder_cfg, &encoder);
 }
 
 namespace {
@@ -49,9 +49,9 @@ esp_err_t init_gpio(gpio_isr_t gpio_isr_handler) {
 } // namespace
 
 /// \todo document
-esp_err_t resume(mdu_encoder_config_t const& encoder_config,
+esp_err_t resume(mdu_encoder_config_t const& encoder_cfg,
                  gpio_isr_t gpio_isr_handler) {
-  ESP_ERROR_CHECK(init_encoder(encoder_config));
+  ESP_ERROR_CHECK(init_encoder(encoder_cfg));
   ESP_ERROR_CHECK(init_alarm());
   return init_gpio(gpio_isr_handler);
 }

--- a/src/drv/out/track/zimo/mdu/resume.hpp
+++ b/src/drv/out/track/zimo/mdu/resume.hpp
@@ -27,8 +27,8 @@
 
 namespace drv::out::track::zimo::mdu {
 
-esp_err_t init_encoder(mdu_encoder_config_t const& encoder_config);
-esp_err_t resume(mdu_encoder_config_t const& encoder_config,
+esp_err_t init_encoder(mdu_encoder_config_t const& encoder_cfg);
+esp_err_t resume(mdu_encoder_config_t const& encoder_cfg,
                  gpio_isr_t gpio_isr_handler);
 
 } // namespace drv::out::track::zimo::mdu

--- a/src/drv8328_test.cpp
+++ b/src/drv8328_test.cpp
@@ -24,19 +24,19 @@
 void drv8328_test() {
   // Inputs and outputs
   {
-    static constexpr gpio_config_t io_conf{
+    static constexpr gpio_config_t gpio_cfg{
       .pin_bit_mask = 1ull << drv::out::track::enable_gpio_num,
       .mode = GPIO_MODE_INPUT_OUTPUT,
       .pull_up_en = GPIO_PULLUP_DISABLE,
       .pull_down_en = GPIO_PULLDOWN_DISABLE,
       .intr_type = GPIO_INTR_DISABLE};
-    ESP_ERROR_CHECK(gpio_config(&io_conf));
+    ESP_ERROR_CHECK(gpio_config(&gpio_cfg));
     ESP_ERROR_CHECK(gpio_set_level(drv::out::track::enable_gpio_num, 0u));
   }
 
   // Outputs
   {
-    static constexpr gpio_config_t io_conf{
+    static constexpr gpio_config_t gpio_cfg{
       .pin_bit_mask = 1ull << drv::led::bug_gpio_num |
                       1ull << drv::out::track::p_gpio_num |
                       1ull << drv::out::track::ilim0_gpio_num |
@@ -48,7 +48,7 @@ void drv8328_test() {
       .pull_up_en = GPIO_PULLUP_DISABLE,
       .pull_down_en = GPIO_PULLDOWN_DISABLE,
       .intr_type = GPIO_INTR_DISABLE};
-    ESP_ERROR_CHECK(gpio_config(&io_conf));
+    ESP_ERROR_CHECK(gpio_config(&gpio_cfg));
     ESP_ERROR_CHECK(gpio_set_level(drv::out::track::p_gpio_num, 1u));
     ESP_ERROR_CHECK(gpio_set_level(drv::out::track::ilim1_gpio_num, 0u));
     ESP_ERROR_CHECK(gpio_set_level(drv::out::track::ilim0_gpio_num, 0u));
@@ -62,13 +62,13 @@ void drv8328_test() {
   vTaskDelay(pdMS_TO_TICKS(100u));
 
   {
-    static constexpr gpio_config_t io_conf{
+    static constexpr gpio_config_t gpio_cfg{
       .pin_bit_mask = 1ull << drv::out::track::nfault_gpio_num,
       .mode = GPIO_MODE_INPUT,
       .pull_up_en = GPIO_PULLUP_ENABLE,
       .pull_down_en = GPIO_PULLDOWN_DISABLE,
       .intr_type = GPIO_INTR_NEGEDGE};
-    ESP_ERROR_CHECK(gpio_config(&io_conf));
+    ESP_ERROR_CHECK(gpio_config(&gpio_cfg));
   }
 
   // Wait 10s
@@ -83,9 +83,11 @@ void drv8328_test() {
   for (;;) {
     ESP_ERROR_CHECK(gpio_set_level(drv::out::track::p_gpio_num, 1u));
     ESP_ERROR_CHECK(gpio_set_level(drv::led::bug_gpio_num, 1u));
-    for (auto then{esp_timer_get_time() + us}; esp_timer_get_time() < then;);
+    for (auto const then{esp_timer_get_time() + us};
+         esp_timer_get_time() < then;);
     ESP_ERROR_CHECK(gpio_set_level(drv::out::track::p_gpio_num, 0u));
     ESP_ERROR_CHECK(gpio_set_level(drv::led::bug_gpio_num, 0u));
-    for (auto then{esp_timer_get_time() + us}; esp_timer_get_time() < then;);
+    for (auto const then{esp_timer_get_time() + us};
+         esp_timer_get_time() < then;);
   }
 }

--- a/src/intf/dns/init.cpp
+++ b/src/intf/dns/init.cpp
@@ -37,16 +37,15 @@ namespace intf::dns {
 /// The DNS server will **not** redirect HTTPS requests.
 esp_err_t init() {
   // Only start DNS in AP mode
-  wifi_mode_t mode;
-  ESP_ERROR_CHECK(esp_wifi_get_mode(&mode));
+  wifi_mode_t mode{WIFI_MODE_NULL};
+  esp_wifi_get_mode(&mode);
 
   // Start the DNS server that will redirect all queries to the softAP IP
   if (mode == WIFI_MODE_AP) {
-    dns_server_config_t config =
+    dns_server_config_t cfg =
       DNS_SERVER_CONFIG_SINGLE("*",            // all A queries
                                "WIFI_AP_DEF"); // softAP netif ID
-
-    start_dns_server(&config);
+    start_dns_server(&cfg);
   }
 
   return ESP_OK;

--- a/src/intf/http/init.cpp
+++ b/src/intf/http/init.cpp
@@ -29,11 +29,9 @@ namespace intf::http {
 
 /// \todo document
 esp_err_t init() {
-  wifi_mode_t mode;
-  ESP_ERROR_CHECK(esp_wifi_get_mode(&mode));
-  if (mode == WIFI_MODE_AP) return ap::init();
-  else if (mode == WIFI_MODE_STA) return sta::init();
-  else return ESP_FAIL;
+  wifi_mode_t mode{WIFI_MODE_NULL};
+  esp_wifi_get_mode(&mode);
+  return mode == WIFI_MODE_AP ? ap::init() : sta::init();
 }
 
 } // namespace intf::http

--- a/src/intf/mdns/init.cpp
+++ b/src/intf/mdns/init.cpp
@@ -44,11 +44,11 @@ esp_err_t init() {
   mem::nvs::Settings nvs;
   auto const sta_mdns_str{nvs.getStationmDNS()};
 
-  // STA mode: hostname is user setting
   // AP mode:  hostname fixed to "remise"
-  wifi_mode_t mode;
-  ESP_ERROR_CHECK(esp_wifi_get_mode(&mode));
-  str = mode == WIFI_MODE_STA && !empty(sta_mdns_str) ? sta_mdns_str : "remise";
+  // STA mode: hostname is user setting
+  wifi_mode_t mode{WIFI_MODE_NULL};
+  esp_wifi_get_mode(&mode);
+  str = mode == WIFI_MODE_AP || empty(sta_mdns_str) ? "remise" : sta_mdns_str;
   ESP_ERROR_CHECK(mdns_hostname_set(str.c_str()));
 
   // Add services


### PR DESCRIPTION
Currently using
- SCLK GPIO_NUM_2
- CS GPIO_NUM_42
- MOSI GPIO_NUM_41
- MISO GPIO_NUM_40

One tricky part will be to decide whether to use Ethernet or WiFi. Obviously if driver installation fails (=no W5500 present) we need to fallback to WiFi, but there will be other cases I assume? I think checking both

1. W5500 presence and
2. Cable installed(?) aka link status is connected

Then we are using Ethernet, otherwise we fallback to WiFi.

Reading the status link bit synchronously is theoretically possible... but it also takes some time until it's set. So there really is no point in using it over the event handler.
```cpp
  uint32_t val{};
  esp_err_t err =
    eth_mac->read_phy_reg(eth_mac, 0, W5500_REG_PHYCFGR, &val); // 1 = BMSR
  LOGI("eth_mac->read_phy_reg %s", esp_err_to_name(err));
  LOGI("val %X", val);
```

Closes #123 