### PR TITLE
VCC voltage measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##
+- Add VCC voltage measurements and hardware revision detection ([#141](https://github.com/OpenRemise/Firmware/pull/141))
+
 ## 0.7.1
 - Add (supported) Z21 settings ([#138](https://github.com/OpenRemise/Firmware/issues/138))
 - Bugfix disable track output when restarting ([#134](https://github.com/OpenRemise/Firmware/issues/134))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,7 +143,7 @@ cpmaddpackage(
 
 # According to this answer here https://stackoverflow.com/a/55312360/5840652
 # magic enum works up to INT16_MAX
-cpmaddpackage("gh:Neargye/magic_enum@0.9.7")
+cpmaddpackage("gh:Neargye/magic_enum@0.9.8")
 math(EXPR INT16_MAX "(1 << 15) - 1" OUTPUT_FORMAT DECIMAL)
 target_compile_definitions(
   magic_enum INTERFACE MAGIC_ENUM_RANGE_MIN=0 MAGIC_ENUM_RANGE_MAX=${INT16_MAX})

--- a/src/app_main.cpp
+++ b/src/app_main.cpp
@@ -47,11 +47,6 @@ extern "C" void app_main() {
   static_assert(PRO_CPU_NUM == 0 && WIFI_TASK_CORE_ID == 0);
   static_assert(APP_CPU_NUM == 1);
 
-  // Use U0RX and U0TX as trace outputs
-#if defined(CONFIG_COMPILER_OPTIMIZATION_DEBUG)
-  ESP_ERROR_CHECK(invoke_on_core(PRO_CPU_NUM, drv::trace::init));
-#endif
-
   // Most important ones
   ESP_ERROR_CHECK(invoke_on_core(PRO_CPU_NUM, mem::nvs::init));
   static_assert(APP_CPU_NUM == mem::nvs::task.core_id);
@@ -72,8 +67,6 @@ extern "C" void app_main() {
   ESP_ERROR_CHECK(invoke_on_core(PRO_CPU_NUM, intf::udp::init));
   ESP_ERROR_CHECK(invoke_on_core(APP_CPU_NUM, mw::dcc::init));
   static_assert(APP_CPU_NUM == mw::dcc::task.core_id);
-  ESP_ERROR_CHECK(invoke_on_core(APP_CPU_NUM, mw::disp::init));
-  static_assert(APP_CPU_NUM == mw::disp::task.core_id);
   ESP_ERROR_CHECK(invoke_on_core(APP_CPU_NUM, mw::ota::init));
   static_assert(APP_CPU_NUM == mw::ota::task.core_id);
   ESP_ERROR_CHECK(invoke_on_core(PRO_CPU_NUM, mw::roco::z21::init));
@@ -86,6 +79,15 @@ extern "C" void app_main() {
   static_assert(APP_CPU_NUM == mw::zimo::zusi::task.core_id);
   ESP_ERROR_CHECK(invoke_on_core(PRO_CPU_NUM, intf::dns::init));
   ESP_ERROR_CHECK(invoke_on_core(PRO_CPU_NUM, intf::mdns::init));
+
+  // Either use U0RX and U0TX as trace outputs
+#if defined(CONFIG_COMPILER_OPTIMIZATION_DEBUG)
+  ESP_ERROR_CHECK(invoke_on_core(PRO_CPU_NUM, drv::trace::init));
+  // ... or as UART display
+#else
+  ESP_ERROR_CHECK(invoke_on_core(APP_CPU_NUM, mw::disp::init));
+  static_assert(APP_CPU_NUM == mw::disp::task.core_id);
+#endif
 
   // Don't disable serial JTAG
 #if !defined(CONFIG_USJ_ENABLE_USB_SERIAL_JTAG)

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -35,6 +35,7 @@
 #include <magic_enum/magic_enum.hpp>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <ztl/enum.hpp>
 #include <ztl/implicit_wrapper.hpp>
@@ -51,6 +52,7 @@
 #  define APP_CPU_NUM 0
 #  define PRO_CPU_NUM APP_CPU_NUM
 #  define WIFI_TASK_CORE_ID APP_CPU_NUM
+#  define ADC_CHANNEL_0 0
 #  define ADC_CHANNEL_1 1
 #  define ADC_CHANNEL_2 2
 #  define ADC_CHANNEL_3 3
@@ -176,6 +178,9 @@ ZTL_MAKE_ENUM_CLASS_FLAGS(State)
 /// Restricts access to low-level tasks
 inline std::atomic<State> state{State::Suspended};
 
+/// Hardware revision
+inline std::string_view revision{"0.0.0"};
+
 namespace drv {
 
 namespace anlg {
@@ -197,31 +202,35 @@ inline constexpr auto current_k{800};
 inline constexpr auto vref{1000};
 inline constexpr auto max_measurement{smath::pow(2, SOC_ADC_DIGI_MAX_BITWIDTH) -
                                       1};
-inline constexpr auto voltage_channel{ADC_CHANNEL_2};
+inline constexpr auto vcc_voltage_channel{ADC_CHANNEL_0};
+inline constexpr auto supply_voltage_channel{ADC_CHANNEL_2};
 inline constexpr auto current_channel{ADC_CHANNEL_9};
 inline constexpr auto attenuation{ADC_ATTEN_DB_0};
-inline constexpr std::array channels{current_channel, voltage_channel};
+inline constexpr std::array channels{
+  vcc_voltage_channel, supply_voltage_channel, current_channel};
 
-/// Sample frequency [Hz] (sample takes 12.5us, conversion frame 20ms)
-///
-/// This frequency was chosen explicitly to avoid any beats with the DCC signal
-/// (~58/100us).
-inline constexpr auto sample_freq_hz{80'000u};
+/// Sample frequency [Hz] (sample takes 12us)
+inline constexpr auto sample_freq_hz{SOC_ADC_SAMPLE_FREQ_THRES_HIGH};
+static_assert(sample_freq_hz == 83333);
 
-/// Number of samples per frame
-inline constexpr auto conversion_frame_samples{1600uz};
+/// Number of samples per frame (84 * 12us = 1008us)
+inline constexpr auto conversion_frame_samples{84uz};
 
-/// Time per frame [ms]
-inline constexpr auto conversion_frame_time{(conversion_frame_samples * 1000u) /
-                                            sample_freq_hz};
-static_assert(conversion_frame_time == 20u);
-
-inline constexpr auto conversion_frame_size{conversion_frame_samples *
-                                            SOC_ADC_DIGI_DATA_BYTES_PER_CONV};
-static_assert(conversion_frame_size == 6400uz);
+/// Number of samples per frame and channel
 inline constexpr auto conversion_frame_samples_per_channel{
   conversion_frame_samples / size(channels)};
+static_assert(conversion_frame_samples_per_channel == 28uz);
 static_assert(size(channels) < SOC_ADC_PATT_LEN_MAX);
+
+/// Time per frame [us]
+inline constexpr auto conversion_frame_time{
+  (conversion_frame_samples * 1000u * 1000u) / sample_freq_hz};
+static_assert(conversion_frame_time == 1008u);
+
+/// Bytes per conversion frame
+inline constexpr auto conversion_frame_size{conversion_frame_samples *
+                                            SOC_ADC_DIGI_DATA_BYTES_PER_CONV};
+static_assert(conversion_frame_size == 336uz);
 
 ///
 inline TASK(adc_task,
@@ -239,35 +248,61 @@ inline TASK(temp_task,
             APP_CPU_NUM,       // Core
             0u);
 
-using VoltageMeasurement =
+using VccVoltageMeasurement =
   ztl::implicit_wrapper<ztl::smallest_signed_t<0, max_measurement>,
-                        struct VoltageMeasurementTag>;
+                        struct VccVoltageMeasurementTag>;
+static_assert(std::same_as<VccVoltageMeasurement::value_type, int16_t>);
 
-using Voltage =
-  ztl::implicit_wrapper<VoltageMeasurement::value_type, struct VoltageTag>;
+using VccVoltage = ztl::implicit_wrapper<VccVoltageMeasurement::value_type,
+                                         struct VccVoltageTag>;
+static_assert(std::same_as<VccVoltage::value_type, int16_t>);
+
+using SupplyVoltageMeasurement =
+  ztl::implicit_wrapper<ztl::smallest_signed_t<0, max_measurement>,
+                        struct SupplyVoltageMeasurementTag>;
+static_assert(std::same_as<SupplyVoltageMeasurement::value_type, int16_t>);
+
+using SupplyVoltage =
+  ztl::implicit_wrapper<SupplyVoltageMeasurement::value_type,
+                        struct SupplyVoltageTag>;
+static_assert(std::same_as<SupplyVoltage::value_type, int16_t>);
 
 using CurrentMeasurement =
   ztl::implicit_wrapper<ztl::smallest_signed_t<0, max_measurement>,
                         struct CurrentMeasurementTag>;
+static_assert(std::same_as<CurrentMeasurement::value_type, int16_t>);
 
 using Current =
   ztl::implicit_wrapper<CurrentMeasurement::value_type, struct CurrentTag>;
+static_assert(std::same_as<Current::value_type, int16_t>);
 
 ///
-inline struct VoltagesQueue {
-  using value_type =
-    std::array<VoltageMeasurement, conversion_frame_samples_per_channel>;
-  static constexpr auto size{1uz};
+inline struct VccVoltagesQueue {
+  using value_type = VccVoltageMeasurement;
+  static constexpr auto size{2000uz};
   static inline QueueHandle_t handle{};
-} voltages_queue;
+} vcc_voltages_queue;
+
+///
+inline struct SupplyVoltagesQueue {
+  using value_type = SupplyVoltageMeasurement;
+  static constexpr auto size{2000uz};
+  static inline QueueHandle_t handle{};
+} supply_voltages_queue;
 
 ///
 inline struct CurrentsQueue {
-  using value_type =
-    std::array<CurrentMeasurement, conversion_frame_samples_per_channel>;
-  static constexpr auto size{1uz};
+  using value_type = CurrentMeasurement;
+  static constexpr auto size{2000uz};
   static inline QueueHandle_t handle{};
 } currents_queue;
+
+///
+inline struct FilteredCurrentQueue {
+  using value_type = CurrentMeasurement;
+  static constexpr auto size{1uz};
+  static inline QueueHandle_t handle{};
+} filtered_current_queue;
 
 ///
 inline struct TemperatureQueue {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -40,6 +40,7 @@
 #include <ztl/enum.hpp>
 #include <ztl/implicit_wrapper.hpp>
 #include <ztl/limits.hpp>
+#include <ztl/moving_average.hpp>
 #include <ztl/string.hpp>
 #include "task.hpp"
 
@@ -235,10 +236,10 @@ static_assert(conversion_frame_size == 336uz);
 ///
 inline TASK(adc_task,
             "drv::anlg::adc",       // Name
-            2048uz,                 // Stack size
+            3072uz,                 // Stack size
             ESP_TASK_PRIO_MAX - 2u, // Priority
             APP_CPU_NUM,            // Core
-            200u);                  // Timeout
+            100u);                  // Timeout
 
 ///
 inline TASK(temp_task,
@@ -275,6 +276,8 @@ static_assert(std::same_as<CurrentMeasurement::value_type, int16_t>);
 using Current =
   ztl::implicit_wrapper<CurrentMeasurement::value_type, struct CurrentTag>;
 static_assert(std::same_as<Current::value_type, int16_t>);
+
+using FilteredCurrent = ztl::moving_average<int32_t, smath::pow(2, 12)>;
 
 ///
 inline struct VccVoltagesQueue {

--- a/src/drv/anlg/adc_task_function.cpp
+++ b/src/drv/anlg/adc_task_function.cpp
@@ -20,6 +20,7 @@
 /// \date   05/07/2023
 
 #include <driver/gpio.h>
+#include <ztl/moving_average.hpp>
 #include "drv/led/bug.hpp"
 #include "init.hpp"
 #include "log.h"
@@ -32,22 +33,18 @@ namespace drv::anlg {
 namespace {
 
 std::array<uint8_t, conversion_frame_size> conversion_frame;
-VoltagesQueue::value_type voltages;
-CurrentsQueue::value_type currents;
+ztl::moving_average<int32_t, smath::pow(2, 12)> filtered_current;
 
-/// Convert the NVS setting "cur_sc_time" to a counter value
-///
-/// For convenience, the \ref mem::nvs::Settings::getCurrentShortCircuitTime()
-/// "short circuit detection time" is stored in milliseconds. In order for this
-/// setting to be used by the ADC task, it must be converted to a counter value.
-///
-/// \return Short circuit counter value for ADC task function
-auto get_short_circuit_count() {
-  return mem::nvs::Settings{}.getCurrentShortCircuitTime() /
-         conversion_frame_time;
+/// \todo document
+BaseType_t xQueueSendOverwriteOldest(QueueHandle_t xQueue,
+                                     void const* pvItemToQueue) {
+  if (!xQueueSend(xQueue, pvItemToQueue, 0u)) {
+    int16_t dummy;
+    xQueueReceive(xQueue, &dummy, 0u);
+    return xQueueSend(xQueue, pvItemToQueue, 0u);
+  }
+  return pdPASS;
 }
-
-} // namespace
 
 /// Handles suspend/resume logic
 ///
@@ -70,6 +67,8 @@ void handle_suspend_resume_on_notify() {
   }
 }
 
+} // namespace
+
 /// Suspend ADC task with task notification
 void adc_task_notify_suspend() {
   xTaskNotifyIndexed(
@@ -85,18 +84,22 @@ void adc_task_notify_resume() {
 /// ADC task function
 ///
 /// Once started, the ADC task runs continuously. It measures voltages and
-/// currents at a frequency of \ref sample_freq_hz "8kHz". A total of \ref
-/// conversion_frame_samples "160" samples are recorded within one conversion
-/// frame meaning one frame lasts exactly \ref conversion_frame_time "20ms". All
-/// measurements are written to the corresponding \ref voltages_queue "voltages"
-/// or \ref currents_queue "currents" queue.
+/// currents at a frequency of \ref sample_freq_hz "83333Hz". A total of \ref
+/// conversion_frame_samples "84" samples are recorded within one conversion
+/// frame meaning one frame lasts approximately \ref conversion_frame_time
+/// "1ms". All measurements are written to the corresponding \ref
+/// vcc_voltages_queue "VCC voltages",
+/// \ref supply_voltages_queue "supply voltages" or
+/// \ref currents_queue "currents" queue.
 ///
 /// If the measured currents indicate a short circuit, the \ref led::bug
 /// "bug LED" is switched on, \ref state is set to \ref State::ShortCircuit
 /// "short circuit" and a \ref page_mw_roco track short circuit message is
 /// broadcast.
 [[noreturn]] void adc_task_function(void*) {
-  auto short_circuit_count{get_short_circuit_count()};
+  auto const initial_short_circuit_time{
+    mem::nvs::Settings{}.getCurrentShortCircuitTime()};
+  auto short_circuit_time{initial_short_circuit_time};
 
   // Start and stop must be called from the same task because the handle uses a
   // FreeRTOS mutex for internal locking
@@ -116,36 +119,45 @@ void adc_task_notify_resume() {
       continue;
     }
 
-    // The following conversion and copy takes 174us
-    auto voltages_it{begin(voltages)};
-    auto currents_it{begin(currents)};
+    // The following conversion and copy takes 359us
+    size_t short_circuit_count{};
     for (auto i{0uz}; i < bytes_received; i += SOC_ADC_DIGI_RESULT_BYTES) {
       auto const output{
         std::bit_cast<adc_digi_output_data_t*>(&conversion_frame[i])};
+      auto const data{static_cast<int16_t>(output->type2.data)};
       auto const chan{output->type2.channel};
-      auto const data{output->type2.data};
-      if (chan == voltage_channel)
-        *voltages_it++ = static_cast<VoltageMeasurement>(data);
-      else if (chan == current_channel)
-        *currents_it++ = static_cast<CurrentMeasurement>(data);
+      switch (chan) {
+        case vcc_voltage_channel:
+          xQueueSendOverwriteOldest(vcc_voltages_queue.handle, &data);
+          break;
+        case supply_voltage_channel:
+          xQueueSendOverwriteOldest(supply_voltages_queue.handle, &data);
+          break;
+        case current_channel:
+          xQueueSendOverwriteOldest(currents_queue.handle, &data);
+          filtered_current += data;
+          short_circuit_count += data == max_measurement;
+          break;
+        default: assert(false); break;
+      }
     }
-    xQueueOverwrite(voltages_queue.handle, &voltages);
-    xQueueOverwrite(currents_queue.handle, &currents);
+    auto const data{static_cast<int16_t>(filtered_current.value())};
+    xQueueOverwrite(filtered_current_queue.handle, &data);
 
     // >90% of all current measurements indicate short circuit
-    if (static constexpr auto ninty_pct{
-          static_cast<size_t>(0.9 * size(currents))};
-        state.load() != State::ShortCircuit &&                       //
-        std::ranges::count(currents, max_measurement) > ninty_pct && //
-        !--short_circuit_count &&                                    //
-        gpio_get_level(out::track::enable_gpio_num)) {               //
+    if (static constexpr auto ninety_pct{
+          static_cast<size_t>(0.9 * conversion_frame_samples_per_channel)};
+        state.load() != State::ShortCircuit &&         // Not ShortCircuit
+        short_circuit_count > ninety_pct &&            // 90% max measurements
+        !--short_circuit_time &&                       // Time until reaction
+        gpio_get_level(out::track::enable_gpio_num)) { // Tracks enabled
       state.store(State::ShortCircuit);
       led::bug(true);
       mw::roco::z21::service->broadcastTrackShortCircuit();
     }
     // Clear count if no short circuit
     else
-      short_circuit_count = get_short_circuit_count();
+      short_circuit_time = initial_short_circuit_time;
 
     // Handle suspend/resume on notify
     handle_suspend_resume_on_notify();

--- a/src/drv/anlg/adc_task_function.cpp
+++ b/src/drv/anlg/adc_task_function.cpp
@@ -25,15 +25,30 @@
 #include "drv/led/bug.hpp"
 #include "init.hpp"
 #include "log.h"
-#include "mem/nvs/settings.hpp"
 #include "mw/roco/z21/service.hpp"
 #include "utility.hpp"
 
 namespace drv::anlg {
 
+/// Cached current short circuit time from NVS
+///
+/// Ugly necessity because `adc_task_function` can't update directly from NVS
+/// due to timing constraints. Instead this value get's updated inside
+/// `temp_task_function`.
+std::atomic<uint8_t> nvs_short_circuit_time;
+
 namespace {
 
-/// \todo document
+/// Send item to queue (even if full)
+///
+/// Small FreeRTOS-style helper to post an item on a queue. As long as there is
+/// still space in the queue, the element is inserted at the end; when the queue
+/// is full, the oldest element is removed first.
+///
+/// \param  xQueue        Queue handle
+/// \param  pvItemToQueue Pointer to the item
+/// \retval pdPASS        Success
+/// \retval errQUEUE_FULL Error
 BaseType_t xQueueSendOverwriteOldest(QueueHandle_t xQueue,
                                      void const* pvItemToQueue) {
   if (!xQueueSend(xQueue, pvItemToQueue, 0u)) {
@@ -44,7 +59,10 @@ BaseType_t xQueueSendOverwriteOldest(QueueHandle_t xQueue,
   return pdPASS;
 }
 
-/// \todo document
+/// Read conversion from to stack
+///
+/// \param  stack Stack
+/// \return Conversion frame
 std::span<uint8_t const> read(std::span<uint8_t> stack) {
   uint32_t bytes_received;
   if (auto const err{adc_continuous_read(adc1_handle,
@@ -61,7 +79,10 @@ std::span<uint8_t const> read(std::span<uint8_t> stack) {
   return stack;
 }
 
-/// \todo document
+/// Detect hardware revision by measuring VCC channel
+///
+/// \param  stack   Stack
+/// \retval ESP_OK  Success
 esp_err_t detect_revision(std::span<uint8_t> stack) {
   // Enable pulldown
   std::underlying_type_t<gpio_num_t> vcc_voltage_gpio_num;
@@ -85,9 +106,8 @@ esp_err_t detect_revision(std::span<uint8_t> stack) {
        i += SOC_ADC_DIGI_RESULT_BYTES) {
     auto const output{
       std::bit_cast<adc_digi_output_data_t*>(&conversion_frame[i])};
-    auto const data{static_cast<int16_t>(output->type2.data)};
-    auto const chan{output->type2.channel};
-    if (chan == vcc_voltage_channel && data > 200) {
+    if (output->type2.channel == vcc_voltage_channel &&
+        output->type2.data > 200u) {
       revision = "0.1.2";
       return ESP_OK;
     }
@@ -97,7 +117,12 @@ esp_err_t detect_revision(std::span<uint8_t> stack) {
   return ESP_OK;
 }
 
-/// \todo document
+/// Parse conversion frame
+///
+/// \tparam revision          Hardware revision
+/// \param  conversion_frame  Conversion frame
+/// \param  filtered_current  Filtered current
+/// \return Number of current samples indicating short circuit
 template<ztl::fixed_string revision>
 size_t parse(std::span<uint8_t const> conversion_frame,
              FilteredCurrent& filtered_current) {
@@ -107,8 +132,7 @@ size_t parse(std::span<uint8_t const> conversion_frame,
     auto const output{
       std::bit_cast<adc_digi_output_data_t*>(&conversion_frame[i])};
     auto const data{static_cast<int16_t>(output->type2.data)};
-    auto const chan{output->type2.channel};
-    switch (chan) {
+    switch (output->type2.channel) {
       case vcc_voltage_channel:
         if constexpr (!ztl::strcmp(revision.c_str(), "0.1.2"))
           xQueueSendOverwriteOldest(vcc_voltages_queue.handle, &data);
@@ -131,6 +155,8 @@ size_t parse(std::span<uint8_t const> conversion_frame,
   return short_circuit_count;
 }
 
+} // namespace
+
 /// Handles suspend/resume logic
 ///
 /// Since the ADC task holds a mutex on the [continuous mode
@@ -152,8 +178,6 @@ void handle_suspend_resume_on_notify() {
   }
 }
 
-} // namespace
-
 /// Suspend ADC task with task notification
 void adc_task_notify_suspend() {
   xTaskNotifyIndexed(
@@ -174,8 +198,9 @@ void adc_task_notify_resume() {
 /// frame meaning one frame lasts approximately \ref conversion_frame_time
 /// "1ms". All measurements are written to the corresponding \ref
 /// vcc_voltages_queue "VCC voltages",
-/// \ref supply_voltages_queue "supply voltages" or
-/// \ref currents_queue "currents" queue.
+/// \ref supply_voltages_queue "supply voltages",
+/// \ref currents_queue "currents" and
+/// \ref filtered_current_queue "filtered current" queue.
 ///
 /// If the measured currents indicate a short circuit, the \ref led::bug
 /// "bug LED" is switched on, \ref state is set to \ref State::ShortCircuit
@@ -184,9 +209,7 @@ void adc_task_notify_resume() {
 [[noreturn]] void adc_task_function(void*) {
   std::array<uint8_t, conversion_frame_size> stack;
   FilteredCurrent filtered_current;
-  auto const initial_short_circuit_time{
-    mem::nvs::Settings{}.getCurrentShortCircuitTime()};
-  auto short_circuit_time{initial_short_circuit_time};
+  uint8_t short_circuit_time{};
 
   // Detect hardware revision by trying to measure VCC
   ESP_ERROR_CHECK(detect_revision(stack));
@@ -215,9 +238,9 @@ void adc_task_notify_resume() {
       led::bug(true);
       mw::roco::z21::service->broadcastTrackShortCircuit();
     }
-    // Clear count if no short circuit
+    // Reset if no short circuit
     else
-      short_circuit_time = initial_short_circuit_time;
+      short_circuit_time = nvs_short_circuit_time.load();
 
     // Handle suspend/resume on notify
     handle_suspend_resume_on_notify();

--- a/src/drv/anlg/adc_task_function.cpp
+++ b/src/drv/anlg/adc_task_function.cpp
@@ -37,6 +37,9 @@ namespace drv::anlg {
 /// `temp_task_function`.
 std::atomic<uint8_t> nvs_short_circuit_time;
 
+/// Short circuit time
+uint8_t short_circuit_time{};
+
 namespace {
 
 /// Send item to queue (even if full)
@@ -155,6 +158,32 @@ size_t parse(std::span<uint8_t const> conversion_frame,
   return short_circuit_count;
 }
 
+/// Detect short circuits
+///
+/// \param  short_circuit_count Number of current samples indicating short
+///                             circuit
+void detect_short_circuit(uint8_t short_circuit_count) {
+  // Reset time if already in short circuit state or tracks disabled
+  if (state.load() == State::ShortCircuit ||
+      !gpio_get_level(out::track::enable_gpio_num)) {
+    short_circuit_time = 0u;
+    return;
+  }
+
+  // >90% of all current measurements indicate short circuit
+  static constexpr auto ninety_pct{
+    static_cast<size_t>(0.9 * conversion_frame_samples_per_channel)};
+  if (short_circuit_count > ninety_pct) ++short_circuit_time;
+  else if (short_circuit_time) --short_circuit_time;
+
+  // Set short circuit state, bug led and transmit broadcast
+  if (short_circuit_time >= nvs_short_circuit_time.load()) {
+    state.store(State::ShortCircuit);
+    led::bug(true);
+    mw::roco::z21::service->broadcastTrackShortCircuit();
+  }
+}
+
 } // namespace
 
 /// Handles suspend/resume logic
@@ -209,11 +238,11 @@ void adc_task_notify_resume() {
 [[noreturn]] void adc_task_function(void*) {
   std::array<uint8_t, conversion_frame_size> stack;
   FilteredCurrent filtered_current;
-  uint8_t short_circuit_time{};
 
   // Detect hardware revision by trying to measure VCC
   ESP_ERROR_CHECK(detect_revision(stack));
-  auto parse_fn{revision.back() == '2' ? &parse<"0.1.2"> : &parse<"0.1.0">};
+  auto const parse_fn{revision.back() == '2' ? &parse<"0.1.2">
+                                             : &parse<"0.1.0">};
 
   // Start
   ESP_ERROR_CHECK(adc_continuous_start(adc1_handle));
@@ -221,26 +250,14 @@ void adc_task_notify_resume() {
   for (;;) {
     // Read conversion frame
     auto const conversion_frame{read(stack)};
-    assert(size(conversion_frame));
+    if (!size(conversion_frame)) continue;
 
     // Parse conversion frame
     auto const short_circuit_count{
       parse_fn(conversion_frame, filtered_current)};
 
-    // >90% of all current measurements indicate short circuit
-    if (static constexpr auto ninety_pct{
-          static_cast<size_t>(0.9 * conversion_frame_samples_per_channel)};
-        state.load() != State::ShortCircuit &&         // Not ShortCircuit
-        short_circuit_count > ninety_pct &&            // 90% max measurements
-        !--short_circuit_time &&                       // Time until reaction
-        gpio_get_level(out::track::enable_gpio_num)) { // Tracks enabled
-      state.store(State::ShortCircuit);
-      led::bug(true);
-      mw::roco::z21::service->broadcastTrackShortCircuit();
-    }
-    // Reset if no short circuit
-    else
-      short_circuit_time = nvs_short_circuit_time.load();
+    // Detect short circuits
+    detect_short_circuit(short_circuit_count);
 
     // Handle suspend/resume on notify
     handle_suspend_resume_on_notify();

--- a/src/drv/anlg/adc_task_function.cpp
+++ b/src/drv/anlg/adc_task_function.cpp
@@ -20,7 +20,8 @@
 /// \date   05/07/2023
 
 #include <driver/gpio.h>
-#include <ztl/moving_average.hpp>
+#include <span>
+#include <ztl/fixed_string.hpp>
 #include "drv/led/bug.hpp"
 #include "init.hpp"
 #include "log.h"
@@ -32,9 +33,6 @@ namespace drv::anlg {
 
 namespace {
 
-std::array<uint8_t, conversion_frame_size> conversion_frame;
-ztl::moving_average<int32_t, smath::pow(2, 12)> filtered_current;
-
 /// \todo document
 BaseType_t xQueueSendOverwriteOldest(QueueHandle_t xQueue,
                                      void const* pvItemToQueue) {
@@ -44,6 +42,93 @@ BaseType_t xQueueSendOverwriteOldest(QueueHandle_t xQueue,
     return xQueueSend(xQueue, pvItemToQueue, 0u);
   }
   return pdPASS;
+}
+
+/// \todo document
+std::span<uint8_t const> read(std::span<uint8_t> stack) {
+  uint32_t bytes_received;
+  if (auto const err{adc_continuous_read(adc1_handle,
+                                         data(stack),
+                                         size(stack),
+                                         &bytes_received,
+                                         adc_task.timeout)}) {
+    LOGE("adc_continuous_read failed %s", esp_err_to_name(err));
+    return {};
+  } else if (bytes_received != size(stack)) {
+    LOGE("Conversion length not equal buffer size");
+    return {};
+  }
+  return stack;
+}
+
+/// \todo document
+esp_err_t detect_revision(std::span<uint8_t> stack) {
+  // Enable pulldown
+  std::underlying_type_t<gpio_num_t> vcc_voltage_gpio_num;
+  ESP_ERROR_CHECK(adc_continuous_channel_to_io(
+    ADC_UNIT_1, vcc_voltage_channel, &vcc_voltage_gpio_num));
+  ESP_ERROR_CHECK(
+    gpio_pulldown_en(static_cast<gpio_num_t>(vcc_voltage_gpio_num)));
+
+  // Read single conversion frame
+  ESP_ERROR_CHECK(adc_continuous_start(adc1_handle));
+  auto const conversion_frame{read(stack)};
+  ESP_ERROR_CHECK(adc_continuous_stop(adc1_handle));
+  ESP_ERROR_CHECK(adc_continuous_flush_pool(adc1_handle));
+
+  // Disable pulldown
+  ESP_ERROR_CHECK(
+    gpio_pulldown_dis(static_cast<gpio_num_t>(vcc_voltage_gpio_num)));
+
+  // Measuring any voltage at all indicates revision 0.1.2
+  for (auto i{0uz}; i < size(conversion_frame);
+       i += SOC_ADC_DIGI_RESULT_BYTES) {
+    auto const output{
+      std::bit_cast<adc_digi_output_data_t*>(&conversion_frame[i])};
+    auto const data{static_cast<int16_t>(output->type2.data)};
+    auto const chan{output->type2.channel};
+    if (chan == vcc_voltage_channel && data > 200) {
+      revision = "0.1.2";
+      return ESP_OK;
+    }
+  }
+
+  revision = "0.1.0";
+  return ESP_OK;
+}
+
+/// \todo document
+template<ztl::fixed_string revision>
+size_t parse(std::span<uint8_t const> conversion_frame,
+             FilteredCurrent& filtered_current) {
+  size_t short_circuit_count{};
+  for (auto i{0uz}; i < size(conversion_frame);
+       i += SOC_ADC_DIGI_RESULT_BYTES) {
+    auto const output{
+      std::bit_cast<adc_digi_output_data_t*>(&conversion_frame[i])};
+    auto const data{static_cast<int16_t>(output->type2.data)};
+    auto const chan{output->type2.channel};
+    switch (chan) {
+      case vcc_voltage_channel:
+        if constexpr (!ztl::strcmp(revision.c_str(), "0.1.2"))
+          xQueueSendOverwriteOldest(vcc_voltages_queue.handle, &data);
+        break;
+      case supply_voltage_channel:
+        xQueueSendOverwriteOldest(supply_voltages_queue.handle, &data);
+        if constexpr (ztl::strcmp(revision.c_str(), "0.1.2"))
+          xQueueSendOverwriteOldest(vcc_voltages_queue.handle, &data);
+        break;
+      case current_channel:
+        xQueueSendOverwriteOldest(currents_queue.handle, &data);
+        filtered_current += data;
+        short_circuit_count += data == max_measurement;
+        break;
+      default: assert(false); break;
+    }
+  }
+  auto const data{static_cast<int16_t>(filtered_current.value())};
+  xQueueOverwrite(filtered_current_queue.handle, &data);
+  return short_circuit_count;
 }
 
 /// Handles suspend/resume logic
@@ -97,52 +182,27 @@ void adc_task_notify_resume() {
 /// "short circuit" and a \ref page_mw_roco track short circuit message is
 /// broadcast.
 [[noreturn]] void adc_task_function(void*) {
+  std::array<uint8_t, conversion_frame_size> stack;
+  FilteredCurrent filtered_current;
   auto const initial_short_circuit_time{
     mem::nvs::Settings{}.getCurrentShortCircuitTime()};
   auto short_circuit_time{initial_short_circuit_time};
 
-  // Start and stop must be called from the same task because the handle uses a
-  // FreeRTOS mutex for internal locking
+  // Detect hardware revision by trying to measure VCC
+  ESP_ERROR_CHECK(detect_revision(stack));
+  auto parse_fn{revision.back() == '2' ? &parse<"0.1.2"> : &parse<"0.1.0">};
+
+  // Start
   ESP_ERROR_CHECK(adc_continuous_start(adc1_handle));
 
   for (;;) {
-    uint32_t bytes_received;
-    if (auto const err{adc_continuous_read(adc1_handle,
-                                           data(conversion_frame),
-                                           size(conversion_frame),
-                                           &bytes_received,
-                                           adc_task.timeout)}) {
-      LOGE("adc_continuous_read failed %s", esp_err_to_name(err));
-      continue;
-    } else if (bytes_received != size(conversion_frame)) {
-      LOGE("Conversion length not equal buffer size");
-      continue;
-    }
+    // Read conversion frame
+    auto const conversion_frame{read(stack)};
+    assert(size(conversion_frame));
 
-    // The following conversion and copy takes 359us
-    size_t short_circuit_count{};
-    for (auto i{0uz}; i < bytes_received; i += SOC_ADC_DIGI_RESULT_BYTES) {
-      auto const output{
-        std::bit_cast<adc_digi_output_data_t*>(&conversion_frame[i])};
-      auto const data{static_cast<int16_t>(output->type2.data)};
-      auto const chan{output->type2.channel};
-      switch (chan) {
-        case vcc_voltage_channel:
-          xQueueSendOverwriteOldest(vcc_voltages_queue.handle, &data);
-          break;
-        case supply_voltage_channel:
-          xQueueSendOverwriteOldest(supply_voltages_queue.handle, &data);
-          break;
-        case current_channel:
-          xQueueSendOverwriteOldest(currents_queue.handle, &data);
-          filtered_current += data;
-          short_circuit_count += data == max_measurement;
-          break;
-        default: assert(false); break;
-      }
-    }
-    auto const data{static_cast<int16_t>(filtered_current.value())};
-    xQueueOverwrite(filtered_current_queue.handle, &data);
+    // Parse conversion frame
+    auto const short_circuit_count{
+      parse_fn(conversion_frame, filtered_current)};
 
     // >90% of all current measurements indicate short circuit
     if (static constexpr auto ninety_pct{

--- a/src/drv/anlg/convert.cpp
+++ b/src/drv/anlg/convert.cpp
@@ -37,25 +37,57 @@ int raw2mV(int meas) {
   return retval;
 }
 
-} // namespace
-
-/// Convert VoltageMeasurement to Voltage
+/// Convert measurement to voltage
 ///
-/// \param  meas  Voltage measurement
+/// \param  meas  Measurement
 /// \return Voltage
-Voltage measurement2mV(VoltageMeasurement meas) {
-  return static_cast<Voltage>(
-    (raw2mV(meas) * (voltage_upper_r + voltage_lower_r)) / voltage_lower_r);
+int measurement2mV(int meas) {
+  return (raw2mV(meas) * (voltage_upper_r + voltage_lower_r)) / voltage_lower_r;
 }
 
-/// Convert Voltage to VoltageMeasurement
+/// Convert voltage to measurement
 ///
 /// \param  mV  Voltage in [mV]
-/// \return VoltageMeasurement
-VoltageMeasurement mV2measurement(Voltage mV) {
-  return static_cast<VoltageMeasurement>(
-    (mV * voltage_lower_r * max_measurement) /
-    ((voltage_upper_r + voltage_lower_r) * vref));
+/// \return Voltage
+int mV2measurement(int mV) {
+  return (mV * voltage_lower_r * max_measurement) /
+         ((voltage_upper_r + voltage_lower_r) * vref);
+}
+
+} // namespace
+
+/// Convert VccVoltageMeasurement to VccVoltage
+///
+/// \param  meas  Vcc voltage measurement
+/// \return VccVoltage
+VccVoltage measurement2mV(VccVoltageMeasurement meas) {
+  return static_cast<VccVoltage>(measurement2mV(static_cast<int>(meas)));
+}
+
+/// Convert VccVoltage to VccVoltageMeasurement
+///
+/// \param  mV  Vcc voltage in [mV]
+/// \return VccVoltageMeasurement
+VccVoltageMeasurement mV2measurement(VccVoltage mV) {
+  return static_cast<VccVoltageMeasurement>(
+    mV2measurement(static_cast<int>(mV)));
+}
+
+/// Convert SupplyVoltageMeasurement to SupplyVoltage
+///
+/// \param  meas  Supply voltage measurement
+/// \return SupplyVoltage
+SupplyVoltage measurement2mV(SupplyVoltageMeasurement meas) {
+  return static_cast<SupplyVoltage>(measurement2mV(static_cast<int>(meas)));
+}
+
+/// Convert SupplyVoltage to SupplyVoltageMeasurement
+///
+/// \param  mV  Supply voltage in [mV]
+/// \return SupplyVoltageMeasurement
+SupplyVoltageMeasurement mV2measurement(SupplyVoltage mV) {
+  return static_cast<SupplyVoltageMeasurement>(
+    mV2measurement(static_cast<int>(mV)));
 }
 
 /// Convert CurrentMeasurement to Current

--- a/src/drv/anlg/convert.hpp
+++ b/src/drv/anlg/convert.hpp
@@ -25,8 +25,10 @@
 
 namespace drv::anlg {
 
-Voltage measurement2mV(VoltageMeasurement meas);
-VoltageMeasurement mV2measurement(Voltage mV);
+VccVoltage measurement2mV(VccVoltageMeasurement meas);
+VccVoltageMeasurement mV2measurement(VccVoltage mV);
+SupplyVoltage measurement2mV(SupplyVoltageMeasurement meas);
+SupplyVoltageMeasurement mV2measurement(SupplyVoltage mV);
 Current measurement2mA(CurrentMeasurement meas);
 CurrentMeasurement mA2measurement(Current mA);
 

--- a/src/drv/anlg/doxygen.hpp
+++ b/src/drv/anlg/doxygen.hpp
@@ -26,8 +26,8 @@ namespace drv::anlg {
 /// \page page_drv_anlg Analog
 /// \details \tableofcontents
 /// This module takes over all analog functions of the firmware. This includes
-/// measuring track voltage and current, measuring temperature, and monitoring
-/// all of those measurements.
+/// measuring supply- and (if available) VCC voltage and current, measuring
+/// temperature, and monitoring all of those measurements.
 ///
 /// \section section_drv_anlg_init Initialization
 /// \copydetails init
@@ -35,7 +35,7 @@ namespace drv::anlg {
 /// \section section_drv_anlg_adc_task ADC task
 /// \copydetails adc_task_function
 ///
-/// \subsection subsection_drv_anlg_adc Suspend/resume ADC task
+/// \subsection subsection_drv_anlg_adc Suspend/resume
 /// \copydetails handle_suspend_resume_on_notify
 ///
 /// \section section_drv_anlg_temp_task Temperature task

--- a/src/drv/anlg/init.cpp
+++ b/src/drv/anlg/init.cpp
@@ -55,19 +55,23 @@ esp_err_t init_gpio() {
 ///
 /// Initialization takes place in init(). This function performs the following
 /// operations:
-/// - Creates queues for raw \ref voltages_queue "voltage" and \ref
-///   currents_queue "current" vales as well as \ref temperature_queue
-///   "temperatures" in Si units
+/// - Creates queues for raw \ref vcc_voltages_queue "VCC voltage", \ref
+///   supply_voltages_queue "supply voltage" and \ref currents_queue "current"
+///   vales as well as \ref temperature_queue "temperatures" in Si units
 /// - Initializes the ADC in [continuous
 ///   mode](https://docs.espressif.com/projects/esp-idf/en/\idf_ver/esp32s3/api-reference/peripherals/adc_continuous.html)
 ///   and applies a curve fitting calibration
 /// - Initializes the internal temperature sensor
 /// - Creates an ADC and temperature task
 esp_err_t init() {
-  voltages_queue.handle =
-    xQueueCreate(voltages_queue.size, sizeof(VoltagesQueue::value_type));
+  vcc_voltages_queue.handle =
+    xQueueCreate(vcc_voltages_queue.size, sizeof(VccVoltagesQueue::value_type));
+  supply_voltages_queue.handle = xQueueCreate(
+    supply_voltages_queue.size, sizeof(SupplyVoltagesQueue::value_type));
   currents_queue.handle =
     xQueueCreate(currents_queue.size, sizeof(CurrentsQueue::value_type));
+  filtered_current_queue.handle = xQueueCreate(
+    filtered_current_queue.size, sizeof(FilteredCurrentQueue::value_type));
   temperature_queue.handle =
     xQueueCreate(temperature_queue.size, sizeof(TemperatureQueue::value_type));
 
@@ -94,7 +98,7 @@ esp_err_t init() {
   };
   ESP_ERROR_CHECK(adc_continuous_new_handle(&adc_cfg, &adc1_handle));
 
-  // Create same pattern for both channels
+  // Create same pattern for all channels
   auto pattern{std::invoke([] {
     std::array<adc_digi_pattern_config_t, size(channels)> retval;
     for (auto i{0uz}; i < size(channels); ++i)

--- a/src/drv/anlg/init.cpp
+++ b/src/drv/anlg/init.cpp
@@ -56,8 +56,9 @@ esp_err_t init_gpio() {
 /// Initialization takes place in init(). This function performs the following
 /// operations:
 /// - Creates queues for raw \ref vcc_voltages_queue "VCC voltage", \ref
-///   supply_voltages_queue "supply voltage" and \ref currents_queue "current"
-///   vales as well as \ref temperature_queue "temperatures" in Si units
+///   supply_voltages_queue "supply voltage", \ref currents_queue "current" and
+///   \ref filtered_current_queue "filtered current" values as well as \ref
+///   temperature_queue "temperatures" in Si units
 /// - Initializes the ADC in [continuous
 ///   mode](https://docs.espressif.com/projects/esp-idf/en/\idf_ver/esp32s3/api-reference/peripherals/adc_continuous.html)
 ///   and applies a curve fitting calibration

--- a/src/drv/anlg/temp_task_function.cpp
+++ b/src/drv/anlg/temp_task_function.cpp
@@ -21,20 +21,30 @@
 
 #include "init.hpp"
 #include "log.h"
+#include "mem/nvs/settings.hpp"
 
 namespace drv::anlg {
+
+extern std::atomic<uint8_t> nvs_short_circuit_time;
 
 /// Temperature task function
 ///
 /// Once started, the temperature task runs continuously. The internal
 /// temperature sensor is read once per second and the result is converted into
-/// degrees Celsius. The result is written to the corresponding queue.
+/// degrees Celsius. The result is written to the corresponding \ref
+/// temperature_queue "temperature" queue.
 [[noreturn]] void temp_task_function(void*) {
   for (;;) {
     TemperatureQueue::value_type temp;
     ESP_ERROR_CHECK(temperature_sensor_get_celsius(temp_sensor, &temp));
     xQueueOverwrite(temperature_queue.handle, &temp);
     vTaskDelay(pdMS_TO_TICKS(1000u));
+
+    // Ugly workaround to update initial short circuit time from NVS. This
+    // atomic is used in the `adc_task_function` but can't be updated there due
+    // to timing constraints.
+    nvs_short_circuit_time.store(
+      mem::nvs::Settings{}.getCurrentShortCircuitTime());
   }
 }
 

--- a/src/drv/anlg/temp_task_function.cpp
+++ b/src/drv/anlg/temp_task_function.cpp
@@ -35,16 +35,16 @@ extern std::atomic<uint8_t> nvs_short_circuit_time;
 /// temperature_queue "temperature" queue.
 [[noreturn]] void temp_task_function(void*) {
   for (;;) {
-    TemperatureQueue::value_type temp;
-    ESP_ERROR_CHECK(temperature_sensor_get_celsius(temp_sensor, &temp));
-    xQueueOverwrite(temperature_queue.handle, &temp);
-    vTaskDelay(pdMS_TO_TICKS(1000u));
-
     // Ugly workaround to update initial short circuit time from NVS. This
     // atomic is used in the `adc_task_function` but can't be updated there due
     // to timing constraints.
     nvs_short_circuit_time.store(
       mem::nvs::Settings{}.getCurrentShortCircuitTime());
+
+    TemperatureQueue::value_type temp;
+    ESP_ERROR_CHECK(temperature_sensor_get_celsius(temp_sensor, &temp));
+    xQueueOverwrite(temperature_queue.handle, &temp);
+    vTaskDelay(pdMS_TO_TICKS(1000u));
   }
 }
 

--- a/src/drv/out/track/dcc/task_function.cpp
+++ b/src/drv/out/track/dcc/task_function.cpp
@@ -266,19 +266,26 @@ esp_err_t operations_loop(dcc_encoder_config_t const& encoder_cfg) {
 
 /// \todo document
 anlg::CurrentMeasurement get_ref_current_measurement() {
-  anlg::CurrentsQueue::value_type currents;
-  if (!xQueueReceive(anlg::currents_queue.handle, &currents, 0u)) assert(false);
-  return anlg::CurrentMeasurement{
-    static_cast<anlg::CurrentMeasurement::value_type>(
-      std::accumulate(cbegin(currents), cend(currents), 0) / ssize(currents))};
+  using namespace anlg;
+  int32_t sum{};
+  auto const count{uxQueueMessagesWaiting(currents_queue.handle)};
+  for (auto i{0uz}; i < count - 1uz; ++i)
+    if (CurrentMeasurement meas;
+        xQueueReceive(currents_queue.handle, &meas, 0u))
+      sum += meas;
+  return CurrentMeasurement{
+    static_cast<CurrentMeasurement::value_type>(sum / (count - 1uz))};
 }
 
 /// \todo document
 template<std::ranges::contiguous_range R>
 void append_current_measurements(R&& r) {
-  anlg::CurrentsQueue::value_type currents;
-  if (xQueueReceive(anlg::currents_queue.handle, &currents, 0u))
-    std::ranges::copy(currents, std::back_inserter(r));
+  using namespace anlg;
+  auto const count{uxQueueMessagesWaiting(currents_queue.handle)};
+  for (auto i{0uz}; i < count - 1uz; ++i)
+    if (CurrentMeasurement meas;
+        xQueueReceive(currents_queue.handle, &meas, 0u))
+      r.push_back(meas);
 }
 
 /// \todo document
@@ -286,14 +293,16 @@ template<std::ranges::contiguous_range R>
 bool detect_ack(R&& r,
                 anlg::CurrentMeasurement ref_current_measurement,
                 anlg::CurrentMeasurement ack_current_measurement) {
+  using namespace anlg;
+
   // ACKs must be at least 5ms long
   static constexpr auto wlen{
-    static_cast<int>(5e-3 * (anlg::sample_freq_hz / size(anlg::channels)))};
-  static_assert(wlen == 200);
+    static_cast<int>(5e-3 * (sample_freq_hz / size(channels)))};
+  static_assert(wlen == 138);
 
   // Initialize rolling sum
   int32_t sum{ref_current_measurement};
-  int32_t zero_count{std::count(cbegin(r), cbegin(r) + wlen, 0)};
+  int32_t zero_count{count(cbegin(r), cbegin(r) + wlen, 0)};
 
   // Slide window
   for (size_t i{wlen}; i < size(r); ++i) {

--- a/src/intf/http/sta/server.cpp
+++ b/src/intf/http/sta/server.cpp
@@ -408,6 +408,8 @@ Response Server::sysGetRequest(Request const& req) {
   doc["compile_date"] = app_desc->date;
   doc["idf_version"] = app_desc->idf_ver + 1; // Remove 'v' prefix
 
+  doc["revision"] = revision;
+
   doc["mdns"] = mdns::str;
   doc["ip"] = drv::wifi::ip_str;
   doc["mac"] = drv::wifi::mac_str;

--- a/src/intf/http/sta/server.cpp
+++ b/src/intf/http/sta/server.cpp
@@ -415,21 +415,17 @@ Response Server::sysGetRequest(Request const& req) {
       esp_wifi_sta_get_ap_info(&ap_record) == ESP_OK)
     doc["rssi"] = ap_record.rssi;
 
-  if (VoltagesQueue::value_type voltages;
-      xQueuePeek(voltages_queue.handle, &voltages, 0u))
-    doc["voltage"] =
-      measurement2mV(static_cast<VoltageMeasurement>(
-                       std::accumulate(cbegin(voltages), cend(voltages), 0) /
-                       size(voltages)))
-        .value();
+  if (SupplyVoltageMeasurement meas;
+      xQueuePeek(supply_voltages_queue.handle, &meas, 0u))
+    doc["supply_voltage"] = measurement2mV(meas).value();
 
-  if (CurrentsQueue::value_type currents;
-      xQueuePeek(currents_queue.handle, &currents, 0u))
-    doc["current"] =
-      measurement2mA(static_cast<CurrentMeasurement>(
-                       std::accumulate(cbegin(currents), cend(currents), 0) /
-                       size(currents)))
-        .value();
+  if (VccVoltageMeasurement meas;
+      xQueuePeek(vcc_voltages_queue.handle, &meas, 0u))
+    doc["vcc_voltage"] = measurement2mV(meas).value();
+
+  if (CurrentMeasurement meas;
+      xQueuePeek(filtered_current_queue.handle, &meas, 0u))
+    doc["current"] = measurement2mA(meas).value();
 
   if (TemperatureQueue::value_type temp;
       xQueuePeek(temperature_queue.handle, &temp, 0u))

--- a/src/mem/nvs/doxygen.hpp
+++ b/src/mem/nvs/doxygen.hpp
@@ -68,7 +68,7 @@ namespace mem::nvs {
 /// | Display a query when leaving the page                                                                                                                 | http_exit_msg   | u8     | 0   | 1   | 1        |
 /// | Current limit in [DCC](https://github.com/ZIMO-Elektronik/DCC) operation mode                                                                         | cur_lim         | u8     | 0   | 3   | 3        |
 /// | Current limit in DCC service mode                                                                                                                     | cur_lim_serv    | u8     | 0   | 3   | 1        |
-/// | Time after which an overcurrent is considered a short circuit [ms]                                                                                    | cur_sc_time     | u8     | 20  | 240 | 100      |
+/// | Time after which an overcurrent is considered a short circuit [ms]                                                                                    | cur_sc_time     | u8     | 1   | 255 | 100      |
 /// | Duty cycle of the bug LED                                                                                                                             | led_dc_bug      | u8     | 0   | 100 | 5        |
 /// | Duty cycle of the WiFi LED                                                                                                                            | led_dc_wifi     | u8     | 0   | 100 | 50       |
 /// | Number of DCC preamble bits                                                                                                                           | dcc_preamble    | u8     | 17  | 30  | 17       |

--- a/src/mem/nvs/settings.cpp
+++ b/src/mem/nvs/settings.cpp
@@ -24,21 +24,6 @@
 
 namespace mem::nvs {
 
-namespace {
-
-/// Round integer towards
-///
-/// \param  n   Value to round
-/// \param  to  Value to round towards to
-/// \return Rounded value
-constexpr auto round_to(std::integral auto n, std::integral auto to) {
-  auto const a{(n / to) * to};
-  auto const b{a + to};
-  return (n - a >= b - n) ? b : a;
-}
-
-} // namespace
-
 /// Get station mDNS
 ///
 /// \return Station mDNS
@@ -372,9 +357,7 @@ uint8_t Settings::getCurrentShortCircuitTime() const {
 /// \retval ESP_ERR_INVALID_ARG           Current short circuit time out of
 ///                                       range
 esp_err_t Settings::setCurrentShortCircuitTime(uint8_t value) {
-  return value >= 20u ? setU8("cur_sc_time",
-                              round_to(value, drv::anlg::conversion_frame_time))
-                      : ESP_ERR_INVALID_ARG;
+  return value >= 1u ? setU8("cur_sc_time", value) : ESP_ERR_INVALID_ARG;
 }
 
 /// Get DCC preamble count

--- a/src/mw/disp/task_function.cpp
+++ b/src/mw/disp/task_function.cpp
@@ -63,22 +63,15 @@ namespace mw::disp {
       if (wifi_ap_record_t ap_record;
           esp_wifi_sta_get_ap_info(&ap_record) == ESP_OK)
         doc["rssi"] = ap_record.rssi;
-      if (VoltagesQueue::value_type voltages;
-          xQueuePeek(voltages_queue.handle, &voltages, 0u))
-        doc["voltage"] =
-          measurement2mV(
-            static_cast<VoltageMeasurement>(
-              std::accumulate(cbegin(voltages), cend(voltages), 0) /
-              size(voltages)))
-            .value();
-      if (CurrentsQueue::value_type currents;
-          xQueuePeek(currents_queue.handle, &currents, 0u))
-        doc["current"] =
-          measurement2mA(
-            static_cast<CurrentMeasurement>(
-              std::accumulate(cbegin(currents), cend(currents), 0) /
-              size(currents)))
-            .value();
+      if (VccVoltageMeasurement meas;
+          xQueuePeek(vcc_voltages_queue.handle, &meas, 0u))
+        doc["vcc_voltage"] = measurement2mV(meas).value();
+      if (SupplyVoltageMeasurement meas;
+          xQueuePeek(supply_voltages_queue.handle, &meas, 0u))
+        doc["supply_voltage"] = measurement2mV(meas).value();
+      if (CurrentMeasurement meas;
+          xQueuePeek(filtered_current_queue.handle, &meas, 0u))
+        doc["current"] = measurement2mA(meas).value();
 
       //
       serializeJson(doc, json);

--- a/src/mw/roco/z21/service.cpp
+++ b/src/mw/roco/z21/service.cpp
@@ -164,14 +164,11 @@ void Service::logoff(z21::Socket const& sock) {
   auto& sys_state{ServerBase::systemState()};
 
   // Currents
-  if (CurrentsQueue::value_type currents;
-      xQueuePeek(currents_queue.handle, &currents, 0u)) {
-    sys_state.main_current = sys_state.prog_current = measurement2mA(
-      static_cast<CurrentMeasurement>(std::ranges::max(currents)));
-    sys_state.filtered_main_current =
-      measurement2mA(static_cast<CurrentMeasurement>(
-        std::accumulate(cbegin(currents), cend(currents), 0) / size(currents)));
-  }
+  if (CurrentMeasurement meas; xQueuePeek(currents_queue.handle, &meas, 0u))
+    sys_state.main_current = sys_state.prog_current = measurement2mA(meas);
+  if (CurrentMeasurement meas;
+      xQueuePeek(filtered_current_queue.handle, &meas, 0u))
+    sys_state.filtered_main_current = measurement2mA(meas);
 
   // Temperature
   if (TemperatureQueue::value_type temp;
@@ -179,13 +176,12 @@ void Service::logoff(z21::Socket const& sock) {
     sys_state.temperature = temp;
 
   // Voltages
-  if (VoltagesQueue::value_type voltages;
-      xQueuePeek(voltages_queue.handle, &voltages, 0u))
-    sys_state.supply_voltage = sys_state.vcc_voltage =
-      measurement2mV(static_cast<VoltageMeasurement>(
-                       std::accumulate(cbegin(voltages), cend(voltages), 0) /
-                       size(voltages)))
-        .value();
+  if (SupplyVoltageMeasurement meas;
+      xQueuePeek(supply_voltages_queue.handle, &meas, 0u))
+    sys_state.supply_voltage = measurement2mV(meas).value();
+  if (VccVoltageMeasurement meas;
+      xQueuePeek(vcc_voltages_queue.handle, &meas, 0u))
+    sys_state.vcc_voltage = measurement2mV(meas).value();
 
   // Central state
   switch (state.load()) {
@@ -347,15 +343,15 @@ void Service::commonSettings(z21::CommonSettings const& common_settings) {
 
 /// \todo document
 z21::MmDccSettings Service::mmDccSettings() {
+  using namespace drv::anlg;
+
   mem::nvs::Settings nvs;
-  uint16_t voltage{};
-  if (drv::anlg::VoltagesQueue::value_type voltages;
-      xQueuePeek(drv::anlg::voltages_queue.handle, &voltages, 0u))
-    voltage =
-      measurement2mV(static_cast<drv::anlg::VoltageMeasurement>(
-                       std::accumulate(cbegin(voltages), cend(voltages), 0) /
-                       size(voltages)))
-        .value();
+
+  decltype(z21::MmDccSettings::output_voltage) voltage{};
+  if (VccVoltageMeasurement meas;
+      xQueuePeek(vcc_voltages_queue.handle, &meas, 0u))
+    voltage = measurement2mV(meas).value();
+
   return {.startup_reset_package_count = nvs.getDccStartupResetPacketCount(),
           .continue_reset_packet_count = nvs.getDccContinueResetPacketCount(),
           .program_package_count = nvs.getDccProgramPacketCount(),

--- a/src/mw/roco/z21/service.cpp
+++ b/src/mw/roco/z21/service.cpp
@@ -185,9 +185,10 @@ void Service::logoff(z21::Socket const& sock) {
 
   // Central state
   switch (state.load()) {
-    // Normally already covered by `adc_task_function`
+    // Can't have track voltage if short
     case State::ShortCircuit:
       sys_state.central_state |= z21::CentralState::ShortCircuit;
+      sys_state.central_state |= z21::CentralState::TrackVoltageOff;
       break;
 
     // Can't be programming mode if off


### PR DESCRIPTION
This PR adds VCC voltage measurements.
It also drastically reduces the frame conversion time. Instead of 20ms a single frame now only takes 1ms! The queues for voltages and current now hold individual values instead of an array. Besides VCC voltage there is now also an extra queue for a "filtered" voltage which is used in the Frontend and Z21 protocol.

The drawback of those changes are that the ADC task now requires a lot of computation by taking 359µs every 1000µs...

TODO:
- ~~Revision detection by VCC measurement~~
- ~~Short circuit detection needs to be tested~~
- ~~Due to the tight loop short circuit time now is only updated when the ADC task is started... this isn't pretty as it would require a reboot every time this setting gets changed~~
- ~~HTTP get request JSON response needs to be adapted~~
- ~~Display JSON needs to be adapted~~
- ~~Frontend code must follow (also cur_sc_time can now be 1 to 255)~~