### PR TITLE
fix: DCC service mode byte only verify never checks for value 255 (#145)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/esp-elf-gcc.yml@v0.3.0
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/esp-elf-gcc.yml@v0.3.1
     with:
       pre-build: |
         sudo apt update -y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##
 - Add VCC voltage measurements and hardware revision detection ([#141](https://github.com/OpenRemise/Firmware/pull/141))
+- Bugfix DCC service mode byte only verify never checks for value 255 ([#145](https://github.com/OpenRemise/Firmware/issues/145))
 
 ## 0.7.1
 - Add (supported) Z21 settings ([#138](https://github.com/OpenRemise/Firmware/issues/138))

--- a/src/mw/dcc/service.cpp
+++ b/src/mw/dcc/service.cpp
@@ -572,7 +572,7 @@ std::optional<uint8_t> Service::serviceRead(uint16_t cv_addr) {
 
   // Byte verify only
   if (_nvs.programming_type == z21::CommonSettings::ProgrammingType::ByteOnly) {
-    for (auto i{0u}; i < std::numeric_limits<uint8_t>::max(); ++i) {
+    for (auto i{0u}; i <= std::numeric_limits<uint8_t>::max(); ++i) {
       sendToFront(make_cv_access_long_verify_service_packet(cv_addr, i),
                   _nvs.program_packet_count);
       if (serviceReceiveBit() == true) return i;


### PR DESCRIPTION
Closes #145 