### PR TITLE
chore: add git identifier to artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8.1
+- Add ᴡʟᴀɴMAUS export ([#164](https://github.com/OpenRemise/Firmware/issues/164))
+
 ## 0.8.0
 - Add VCC voltage measurements and hardware revision detection ([#141](https://github.com/OpenRemise/Firmware/pull/141))
 - Add Z21 `LAN_X_SET_LOCO_NAME` ([#164](https://github.com/OpenRemise/Firmware/issues/164))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,6 @@ if(ESP_PLATFORM
       Frontend
       URL
       "https://github.com/OpenRemise/Frontend/releases/download/v${VERSION_FROM_GIT}/Frontend-${VERSION_FROM_GIT}.zip"
-      VERSION
-      ${OPENREMISE_FRONTENVERSION_FROM_GITD_VERSION}
       DOWNLOAD_ONLY
       ON)
     set(FRONTEND_WEB_DIR ${Frontend_SOURCE_DIR})
@@ -133,7 +131,8 @@ if(ESP_PLATFORM AND NOT IDF_TARGET STREQUAL linux)
   add_custom_target(
     FirmwareRelease
     COMMAND
-      ${CMAKE_COMMAND} -E tar "cf" ${PROJECT_NAME}-${PROJECT_VERSION}.zip
+      ${CMAKE_COMMAND} -E tar "cf"
+      ${PROJECT_NAME}-${PROJECT_VERSION}${IDENTIFIERS_FROM_GIT}.zip
       --format=zip #
       flasher_args.json #
       bootloader/bootloader.bin #


### PR DESCRIPTION
Append git identifiers to the generated artifacts to make it easier to distinguish between builds in the future.